### PR TITLE
Ignore /health and /root endpoints from swagger doc as they are just …

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/config/SwaggerConfiguration.java
@@ -1,16 +1,13 @@
 package uk.gov.hmcts.reform.sscscorbackend.config;
 
-import com.google.common.base.Predicate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import springfox.documentation.RequestHandler;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 import uk.gov.hmcts.reform.sscscorbackend.Application;
-import uk.gov.hmcts.reform.sscscorbackend.controllers.RootController;
 
 @Configuration
 @EnableSwagger2
@@ -19,12 +16,11 @@ public class SwaggerConfiguration {
     @Bean
 
     public Docket api() {
-        Predicate<RequestHandler> selector = RequestHandlerSelectors.basePackage(Application.class.getPackage().getName() + ".controllers");
         return new Docket(DocumentationType.SWAGGER_2)
-            .useDefaultResponseMessages(false)
-            .select()
-            .apis(input -> selector.apply(input) && !input.declaringClass().equals(RootController.class))
-            .paths(PathSelectors.any())
-            .build();
+                .useDefaultResponseMessages(false)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage(Application.class.getPackage().getName() + ".controllers"))
+                .paths(PathSelectors.any())
+                .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/HealthController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/HealthController.java
@@ -4,8 +4,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
+@ApiIgnore
 public class HealthController {
 
     @RequestMapping(method = RequestMethod.GET, value = "/health", produces = "application/json")

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/RootController.java
@@ -5,11 +5,13 @@ import static org.springframework.http.ResponseEntity.ok;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 /**
  * Default endpoints per application.
  */
 @RestController
+@ApiIgnore
 public class RootController {
 
     /**

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,10 +1,9 @@
 server:
   port: ${PORT:8090}
 
-#If you use a database then uncomment below lines and update db properties accordingly leaving tomcat connection settings unchanged.
 spring:
   application:
-    name: Spring Boot Template
+    name: SSCS-COR-Backend
 
 coh:
   url: ${COH_URL:http://localhost:8081}


### PR DESCRIPTION
…there for infrastructural reasons not to be consumed by clients.