### PR TITLE
Small tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ docker image rm <image-id>
 
 There is no need to remove postgres and java or similar core images.
 
+## Functional tests
+
+Can be run in your ide or with
+
+```bash
+  ./gradlew functional
+``` 
+
+These tests will always run against COH on aat but you can set the url for sscs-backend-cor with the TEST_URL
+environment variable.
+
+If you are running this test locally you will need to set the USE_COH_PROXY environment variable to true.
+
+If you are running this test locally and the sscs-backend-cor is remote i.e. in preview or AAT environment then you need
+to set the USE_BACKEND_PROXY environment variable to true.
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
@@ -27,14 +27,6 @@ import org.junit.Before;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
-/*
- This test will always run against COH on aat but you can set the url for sscs-backend-cor with the TEST_URL environment
- variable.
-
- If you are running this test locally you will need to set the USE_COH_PROXY environment variable to true.
- If you are running this test locally and the sscs-backend-cor is remote i.e. in preview or AAT environment then you
- need to set the USE_BACKEND_PROXY environment variable to true.
- */
 public abstract class BaseFunctionTest {
     protected final String baseUrl = System.getenv("TEST_URL");
     protected CloseableHttpClient client;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/TokenGeneratorStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/TokenGeneratorStub.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 
@@ -16,9 +14,16 @@ public class TokenGeneratorStub {
         wireMock.stubFor(post(urlEqualTo("/lease"))
                 .willReturn(ok("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzc2NzIiwiZXhwIjoxNTMzNjY5MTgyfQ.Tr6nlcxFptSp9qPcgImowv5yDivPeX32nLwumDAEJgAEt4U_RHYx1gUJyK7GqRe1o1eE-tCNbaNMW5OIbbENdg")
                         .withHeader("Content-Type", "text/plain;charset=UTF-8")));
+
+        wireMock.stubFor(get(urlEqualTo("/health"))
+                .willReturn(okJson("{\"status\": \"UP\"}")));
     }
 
     public void shutdown() {
         wireMock.stop();
+    }
+
+    public static void main(String[] args) {
+        new TokenGeneratorStub("http://localhost:4502");
     }
 }


### PR DESCRIPTION
Add a main method to the TokenGeneratorStub. This then lets 
us run this rather than starting the whole docker image for the 
s2s auth app. Handy when developing functional tests.

Added Instructions for running functional tests to the README.