### PR TITLE
[PREVIEW] SSCS-3581 Submit the answer to a question.

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
@@ -1,66 +1,35 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
-import static org.apache.http.client.methods.RequestBuilder.post;
-import static org.apache.http.client.methods.RequestBuilder.put;
 import static org.apache.http.conn.ssl.SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER;
-import static org.apache.http.entity.ContentType.APPLICATION_JSON;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.util.UUID;
 import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
-import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
-import org.apache.http.util.EntityUtils;
-import org.json.JSONObject;
 import org.junit.Before;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 
 public abstract class BaseFunctionTest {
-    protected final String baseUrl = System.getenv("TEST_URL");
-    protected CloseableHttpClient client;
+    private final String baseUrl = System.getenv("TEST_URL");
+    private CloseableHttpClient client;
     // private final String baseUrl = "http://sscs-cor-backend-aat-staging.service.core-compute-aat.internal";
     private String cohBaseUrl = "http://coh-cor-aat.service.core-compute-aat.internal";
     private HttpClient cohClient;
 
-    private static String makePostRequest(HttpClient client, String uri, String body, String responseValue) throws IOException {
-        HttpResponse httpResponse = client.execute(post(uri)
-                .setHeader(HttpHeaders.AUTHORIZATION, "someValue")
-                .setHeader("ServiceAuthorization", "someValue")
-                .setEntity(new StringEntity(body, APPLICATION_JSON))
-                .build());
-
-        assertThat(httpResponse.getStatusLine().getStatusCode(), is(HttpStatus.CREATED.value()));
-        String responseBody = EntityUtils.toString(httpResponse.getEntity());
-
-        return new JSONObject(responseBody).getString(responseValue);
-    }
-
-    private static void makePutRequest(HttpClient client, String uri, String body) throws IOException {
-        HttpResponse httpResponse = client.execute(put(uri)
-                .setHeader(HttpHeaders.AUTHORIZATION, "someValue")
-                .setHeader("ServiceAuthorization", "someValue")
-                .setEntity(new StringEntity(body, APPLICATION_JSON))
-                .build());
-
-        assertThat(httpResponse.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
-    }
+    protected SscsCorBackendRequests sscsCorBackendRequests;
+    protected CohRequests cohRequests;
 
     @Before
     public void setUp() throws Exception {
         cohClient = buildClient("USE_COH_PROXY");
         client = buildClient("USE_BACKEND_PROXY");
+        sscsCorBackendRequests = new SscsCorBackendRequests(baseUrl, client);
+        cohRequests = new CohRequests(cohBaseUrl, cohClient);
     }
 
     private CloseableHttpClient buildClient(String proxySystemProperty) throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
@@ -77,48 +46,4 @@ public abstract class BaseFunctionTest {
         return httpClientBuilder.build();
     }
 
-    protected void answerQuestion(String hearingId, String questionId, String answer) throws IOException {
-        HttpResponse getQuestionResponse = client.execute(put(baseUrl + "/continuous-online-hearings/" + hearingId + "/questions/" + questionId)
-                .setEntity(new StringEntity("{\"answer\":\"" + answer + "\"}", APPLICATION_JSON))
-                .build());
-
-        assertThat(getQuestionResponse.getStatusLine().getStatusCode(), is(HttpStatus.NO_CONTENT.value()));
-    }
-
-    protected String createHearing() throws IOException {
-        String hearingId = makePostRequest(cohClient, cohBaseUrl + "/continuous-online-hearings", "{\n" +
-                "  \"case_id\": \"" + UUID.randomUUID().toString() + "\",\n" +
-                "  \"jurisdiction\": \"SSCS\",\n" +
-                "  \"panel\": [\n" +
-                "    {\n" +
-                "      \"identity_token\": \"Judge\",\n" +
-                "      \"name\": \"John Dead\"\n" +
-                "    }\n" +
-                "  ],\n" +
-                "  \"start_date\": \"2018-08-09T13:14:45.178Z\",\n" +
-                "  \"state\": \"continuous_online_hearing_started\"\n" +
-                "}", "online_hearing_id");
-        System.out.println("Hearing id " + hearingId);
-        return hearingId;
-    }
-
-    protected String createQuestion(String hearingId) throws IOException {
-        String questionId = makePostRequest(cohClient, cohBaseUrl + "/continuous-online-hearings/" + hearingId + "/questions",
-                "{\n" +
-                        "  \"owner_reference\": \"owner_ref\",\n" +
-                        "  \"question_body_text\": \"question text\",\n" +
-                        "  \"question_header_text\": \"question header\",\n" +
-                        "  \"question_ordinal\": \"1\",\n" +
-                        "  \"question_round\": \"1\"\n" +
-                        "}",
-                "question_id");
-        System.out.println("Question id " + questionId);
-        return questionId;
-    }
-
-    protected void issueQuestionRound(String hearingId) throws IOException {
-        makePutRequest(cohClient, cohBaseUrl + "/continuous-online-hearings/" + hearingId + "/questionrounds/1",
-                "{\"state_name\": \"question_issue_pending\"}"
-        );
-    }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohRequests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohRequests.java
@@ -1,0 +1,88 @@
+package uk.gov.hmcts.reform.sscscorbackend;
+
+import static org.apache.http.client.methods.RequestBuilder.post;
+import static org.apache.http.client.methods.RequestBuilder.put;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.util.UUID;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+public class CohRequests {
+    private String cohBaseUrl;
+    private HttpClient cohClient;
+
+    public CohRequests(String cohBaseUrl, HttpClient cohClient) {
+        this.cohBaseUrl = cohBaseUrl;
+        this.cohClient = cohClient;
+    }
+
+    public String createHearing() throws IOException {
+        String hearingId = makePostRequest(cohClient, cohBaseUrl + "/continuous-online-hearings", "{\n" +
+                "  \"case_id\": \"" + UUID.randomUUID().toString() + "\",\n" +
+                "  \"jurisdiction\": \"SSCS\",\n" +
+                "  \"panel\": [\n" +
+                "    {\n" +
+                "      \"identity_token\": \"Judge\",\n" +
+                "      \"name\": \"John Dead\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"start_date\": \"2018-08-09T13:14:45.178Z\",\n" +
+                "  \"state\": \"continuous_online_hearing_started\"\n" +
+                "}", "online_hearing_id");
+        System.out.println("Hearing id " + hearingId);
+        return hearingId;
+    }
+
+    public String createQuestion(String hearingId) throws IOException {
+        String questionId = makePostRequest(cohClient, cohBaseUrl + "/continuous-online-hearings/" + hearingId + "/questions",
+                "{\n" +
+                        "  \"owner_reference\": \"owner_ref\",\n" +
+                        "  \"question_body_text\": \"question text\",\n" +
+                        "  \"question_header_text\": \"question header\",\n" +
+                        "  \"question_ordinal\": \"1\",\n" +
+                        "  \"question_round\": \"1\"\n" +
+                        "}",
+                "question_id");
+        System.out.println("Question id " + questionId);
+        return questionId;
+    }
+
+    public void issueQuestionRound(String hearingId) throws IOException {
+        makePutRequest(cohClient, cohBaseUrl + "/continuous-online-hearings/" + hearingId + "/questionrounds/1",
+                "{\"state_name\": \"question_issue_pending\"}"
+        );
+    }
+
+    private static String makePostRequest(HttpClient client, String uri, String body, String responseValue) throws IOException {
+        HttpResponse httpResponse = client.execute(post(uri)
+                .setHeader(HttpHeaders.AUTHORIZATION, "someValue")
+                .setHeader("ServiceAuthorization", "someValue")
+                .setEntity(new StringEntity(body, APPLICATION_JSON))
+                .build());
+
+        assertThat(httpResponse.getStatusLine().getStatusCode(), is(HttpStatus.CREATED.value()));
+        String responseBody = EntityUtils.toString(httpResponse.getEntity());
+
+        return new JSONObject(responseBody).getString(responseValue);
+    }
+
+    private static void makePutRequest(HttpClient client, String uri, String body) throws IOException {
+        HttpResponse httpResponse = client.execute(put(uri)
+                .setHeader(HttpHeaders.AUTHORIZATION, "someValue")
+                .setHeader("ServiceAuthorization", "someValue")
+                .setEntity(new StringEntity(body, APPLICATION_JSON))
+                .build());
+
+        assertThat(httpResponse.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
+    }
+
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAQuestion.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAQuestion.java
@@ -1,52 +1,44 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
-import static org.apache.http.client.methods.RequestBuilder.get;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.submitted;
 
 import java.io.IOException;
-import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.springframework.http.HttpStatus;
 
 public class GetAQuestion extends BaseFunctionTest {
 
     @Test
     public void getsAndAnswersAQuestion() throws IOException, InterruptedException {
-        String hearingId = createHearing();
-        String questionId = createQuestion(hearingId);
-        issueQuestionRound(hearingId);
+        String hearingId = cohRequests.createHearing();
+        String questionId = cohRequests.createQuestion(hearingId);
+        cohRequests.issueQuestionRound(hearingId);
 
-        JSONObject jsonObject = getQuestion(hearingId, questionId);
+        JSONObject jsonObject = sscsCorBackendRequests.getQuestion(hearingId, questionId);
         String questionBodyText = jsonObject.getString("question_body_text");
         String answer = jsonObject.optString("answer", null);
 
         assertThat(questionBodyText, is("question text"));
         assertThat(answer, is(nullValue()));
 
-        Thread.sleep(60000L);
+        Thread.sleep(5000L);
 
         String expectedAnswer = "an answer";
-        answerQuestion(hearingId, questionId, expectedAnswer);
+        sscsCorBackendRequests.answerQuestion(hearingId, questionId, expectedAnswer);
 
-        jsonObject = getQuestion(hearingId, questionId);
+        jsonObject = sscsCorBackendRequests.getQuestion(hearingId, questionId);
         answer = jsonObject.optString("answer", expectedAnswer);
 
         assertThat(answer, is(expectedAnswer));
+
+        sscsCorBackendRequests.submitAnswer(hearingId, questionId);
+
+        JSONObject questionRound = sscsCorBackendRequests.getQuestions(hearingId);
+        JSONArray questions = questionRound.getJSONArray("questions");
+        assertThat(questions.getJSONObject(0).getString("answer_state"), is(submitted.name()));
     }
-
-    private JSONObject getQuestion(String hearingId, String questionId) throws IOException {
-        HttpResponse getQuestionResponse = client.execute(get(baseUrl + "/continuous-online-hearings/" + hearingId + "/questions/" + questionId)
-                .build());
-
-        assertThat(getQuestionResponse.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
-
-        String responseBody = EntityUtils.toString(getQuestionResponse.getEntity());
-
-        return new JSONObject(responseBody);
-    }
-
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetListOfQuestions.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetListOfQuestions.java
@@ -1,42 +1,27 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
-import static org.apache.http.client.methods.RequestBuilder.get;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
-import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.http.HttpStatus;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 public class GetListOfQuestions extends BaseFunctionTest {
     @Test
     public void getAListOfQuestionTitles() throws IOException {
-        String hearingId = createHearing();
-        String questionId = createQuestion(hearingId);
+        String hearingId = cohRequests.createHearing();
+        String questionId = cohRequests.createQuestion(hearingId);
 
-        JSONObject questionRound = getQuestions(hearingId);
+        JSONObject questionRound = sscsCorBackendRequests.getQuestions(hearingId);
         JSONArray questions = questionRound.getJSONArray("questions");
 
         assertThat(questions.length(), is(1));
         assertThat(questions.getJSONObject(0).getString("question_header_text"), is("question header"));
         assertThat(questions.getJSONObject(0).getString("question_id"), is(questionId));
-    }
-
-    private JSONObject getQuestions(String hearingId) throws IOException {
-        HttpResponse getQuestionResponse = client.execute(get(baseUrl + "/continuous-online-hearings/" + hearingId)
-                .build());
-
-        assertThat(getQuestionResponse.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
-
-        String responseBody = EntityUtils.toString(getQuestionResponse.getEntity());
-
-        return new JSONObject(responseBody);
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/SscsCorBackendRequests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/SscsCorBackendRequests.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.reform.sscscorbackend;
+
+import static org.apache.http.client.methods.RequestBuilder.get;
+import static org.apache.http.client.methods.RequestBuilder.post;
+import static org.apache.http.client.methods.RequestBuilder.put;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+import org.springframework.http.HttpStatus;
+
+public class SscsCorBackendRequests {
+    private String baseUrl;
+    private CloseableHttpClient client;
+
+    public SscsCorBackendRequests(String baseUrl, CloseableHttpClient client) {
+        this.baseUrl = baseUrl;
+        this.client = client;
+    }
+
+    public JSONObject getQuestion(String hearingId, String questionId) throws IOException {
+        HttpResponse getQuestionResponse = client.execute(get(baseUrl + "/continuous-online-hearings/" + hearingId + "/questions/" + questionId)
+                .build());
+
+        assertThat(getQuestionResponse.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
+
+        String responseBody = EntityUtils.toString(getQuestionResponse.getEntity());
+
+        return new JSONObject(responseBody);
+    }
+
+    public JSONObject getQuestions(String hearingId) throws IOException {
+        HttpResponse getQuestionResponse = client.execute(get(baseUrl + "/continuous-online-hearings/" + hearingId)
+                .build());
+
+        assertThat(getQuestionResponse.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
+
+        String responseBody = EntityUtils.toString(getQuestionResponse.getEntity());
+
+        return new JSONObject(responseBody);
+    }
+
+    public void answerQuestion(String hearingId, String questionId, String answer) throws IOException {
+        HttpResponse getQuestionResponse = client.execute(put(baseUrl + "/continuous-online-hearings/" + hearingId + "/questions/" + questionId)
+                .setEntity(new StringEntity("{\"answer\":\"" + answer + "\"}", APPLICATION_JSON))
+                .build());
+
+        assertThat(getQuestionResponse.getStatusLine().getStatusCode(), is(HttpStatus.NO_CONTENT.value()));
+    }
+
+    public void submitAnswer(String hearingId, String questionId) throws IOException {
+        HttpResponse getQuestionResponse = client.execute(post(baseUrl + "/continuous-online-hearings/" + hearingId + "/questions/" + questionId)
+                .setHeader("Content-Length", "0")
+                .build());
+
+        assertThat(getQuestionResponse.getStatusLine().getStatusCode(), is(HttpStatus.NO_CONTENT.value()));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohStub.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscscorbackend;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.util.stream.Collectors.joining;
+import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.draft;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
@@ -169,9 +170,13 @@ public class CohStub {
     }
 
     public void stubUpdateAnswer(String hearingId, String questionId, String newAnswer, String answerId) {
+        stubUpdateAnswer(hearingId, questionId, newAnswer, answerId, draft);
+    }
+
+    public void stubUpdateAnswer(String hearingId, String questionId, String newAnswer, String answerId, AnswerState answerState) {
         wireMock.stubFor(put("/continuous-online-hearings/" + hearingId + "/questions/" + questionId + "/answers/" + answerId)
                 .withHeader("ServiceAuthorization", new RegexPattern(".*"))
-                .withRequestBody(equalToJson("{\"answer_state\":\"answer_drafted\", \"answer_text\":\"" + newAnswer + "\"}"))
+                .withRequestBody(equalToJson("{\"answer_state\":\"" + answerState.getCohAnswerState() + "\", \"answer_text\":\"" + newAnswer + "\"}"))
                 .willReturn(created())
         );
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.submitted;
 
 import io.restassured.RestAssured;
 import java.util.UUID;
@@ -83,5 +84,22 @@ public class QuestionControllerTest extends BaseIntegrationTest {
                 .get("/continuous-online-hearings/" + hearingId + "/questions/" + questionId)
                 .then()
                 .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    public void submitAnAnswerToAQuestion() {
+        String hearingId = "1";
+        String questionId = "1";;
+        String answerId = UUID.randomUUID().toString();
+        String answer = "answer";
+        cohStub.stubGetAnswer(hearingId, questionId, answer, answerId);
+        cohStub.stubUpdateAnswer(hearingId, questionId, answer, answerId, submitted);
+
+        RestAssured.baseURI = "http://localhost:" + applicationPort;
+        RestAssured.given()
+                .when()
+                .post("/continuous-online-hearings/" + hearingId + "/questions/" + questionId)
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionController.java
@@ -64,4 +64,23 @@ public class QuestionController {
         questionService.updateAnswer(onlineHearingId, questionId, newAnswer.getAnswer());
         return ResponseEntity.noContent().build();
     }
+
+    @ApiOperation(value = "Submit an answer to a question",
+            notes = "The question must be answered first then it can be submitted"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Answer saved"),
+            @ApiResponse(code = 404, message = "Question has not already been answered")
+    })
+    @RequestMapping(method = RequestMethod.POST, value = "questions/{questionId}")
+    @ResponseStatus(value = HttpStatus.NO_CONTENT)
+    public ResponseEntity<Void> submitAnswer(@PathVariable String onlineHearingId,
+                                             @PathVariable String questionId) {
+        boolean answerSubmitted = questionService.submitAnswer(onlineHearingId, questionId);
+        if (answerSubmitted) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
@@ -34,13 +34,27 @@ public class QuestionService {
 
     public void updateAnswer(String onlineHearingId, String questionId, String newAnswer) {
         List<CohAnswer> answers = cohClient.getAnswers(onlineHearingId, questionId);
-        CohUpdateAnswer updatedAnswer = new CohUpdateAnswer("answer_drafted", newAnswer);
+        CohUpdateAnswer updatedAnswer = new CohUpdateAnswer(AnswerState.draft.getCohAnswerState(), newAnswer);
         if (answers == null || answers.isEmpty()) {
             cohClient.createAnswer(onlineHearingId, questionId, updatedAnswer);
         } else {
             String answerId = answers.get(0).getAnswerId();
             cohClient.updateAnswer(onlineHearingId, questionId, answerId, updatedAnswer);
         }
+    }
+
+    public boolean submitAnswer(String onlineHearingId, String questionId) {
+        List<CohAnswer> answers = cohClient.getAnswers(onlineHearingId, questionId);
+
+        return answers.stream().findFirst()
+                .map(answer -> {
+                    CohUpdateAnswer updatedAnswer = new CohUpdateAnswer(AnswerState.submitted.getCohAnswerState(), answer.getAnswerText());
+                    String answerId = answers.get(0).getAnswerId();
+                    cohClient.updateAnswer(onlineHearingId, questionId, answerId, updatedAnswer);
+
+                    return true;
+                })
+                .orElse(false);
     }
 
     public QuestionRound getQuestions(String onlineHearingId) {
@@ -69,6 +83,7 @@ public class QuestionService {
         return new QuestionSummary(
                 cohQuestionReference.getQuestionId(),
                 cohQuestionReference.getQuestionHeaderText(),
-                answerState);
+                answerState
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionControllerTest.java
@@ -81,4 +81,20 @@ public class QuestionControllerTest {
         assertThat(response.getStatusCode(), is(HttpStatus.NO_CONTENT));
         verify(questionService).updateAnswer(onlineHearingId, questionId, newAnswer);
     }
+
+    @Test
+    public void submitsAnswer() {
+        when(questionService.submitAnswer(onlineHearingId, questionId)).thenReturn(true);
+        ResponseEntity response = underTest.submitAnswer(onlineHearingId, questionId);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NO_CONTENT));
+    }
+
+    @Test
+    public void cannotFindAnswerToSubmit() {
+        when(questionService.submitAnswer(onlineHearingId, questionId)).thenReturn(false);
+        ResponseEntity response = underTest.submitAnswer(onlineHearingId, questionId);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+    }
 }


### PR DESCRIPTION
Added a new endpoint to submit a answer. The endpoint is just a post to /continuous-online-hearings/{hearing_id}/questions/{questionId}. Decided to to do it this was as the frontend saves the answer in draft then loads a confirmation page before submitting the answer. Originally was going to just add a status in the body of the updateAnswer endpoint but that would have meant the frontend would have needed to reload the answer. As the backend was already loading the answer to check if it existed though it better to do it this way.