### PR TITLE
[PREVIEW] Poll to find out if round has been issued

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAQuestion.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAQuestion.java
@@ -25,8 +25,6 @@ public class GetAQuestion extends BaseFunctionTest {
         assertThat(questionBodyText, is("question text"));
         assertThat(answer, is(nullValue()));
 
-        Thread.sleep(5000L);
-
         String expectedAnswer = "an answer";
         sscsCorBackendRequests.answerQuestion(hearingId, questionId, expectedAnswer);
 


### PR DESCRIPTION
Until now we were sleeping to give the Coh system time to issue a round
of questions as this is a backend process for them. Changed this to
poll and check the status of the round before continuing. Will timeout
if the round has not been issued in 10 seconds.