### PR TITLE
Deadline expiry date and question answer date were in different formats.

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohStub.java
@@ -8,7 +8,6 @@ import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.draft;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import java.io.UnsupportedEncodingException;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -209,7 +208,7 @@ public class CohStub extends BaseStub {
                         .replace("{question_header}", questionSummary.getQuestionHeaderText())
                         .replace("{question_id}", questionSummary.getQuestionId())
                         .replace("{answer_state}", questionSummary.getAnswers().get(0).getCurrentAnswerState().getStateName())
-                        .replace("{deadline_expiry_date}", questionSummary.getDeadlineExpiryDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                        .replace("{deadline_expiry_date}", questionSummary.getDeadlineExpiryDate())
                 )
                 .collect(joining(", ", "[", "]"));
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/ListQuestionsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/ListQuestionsTest.java
@@ -1,10 +1,11 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
+import static java.time.LocalDateTime.now;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someCohAnswers;
 
 import io.restassured.RestAssured;
-import java.time.LocalDateTime;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.sscscorbackend.domain.CohQuestionReference;
@@ -13,8 +14,13 @@ public class ListQuestionsTest extends BaseIntegrationTest {
     @Test
     public void getQuestion() {
         String hearingId = "1";
-        CohQuestionReference firstQuestionSummary = new CohQuestionReference("first-id", 1, "first question", LocalDateTime.now().plusDays(7), someCohAnswers("answer_drafted"));
-        CohQuestionReference secondQuestionSummary = new CohQuestionReference("second-id", 2, "second question", LocalDateTime.now().plusDays(7), someCohAnswers("answer_submitted"));
+        String deadlineExpiryDate = now().plusDays(7).format(ISO_LOCAL_DATE_TIME);
+        CohQuestionReference firstQuestionSummary = new CohQuestionReference(
+                "first-id", 1, "first question", deadlineExpiryDate, someCohAnswers("answer_drafted")
+        );
+        CohQuestionReference secondQuestionSummary = new CohQuestionReference(
+                "second-id", 2, "second question", deadlineExpiryDate, someCohAnswers("answer_submitted")
+        );
         cohStub.stubGetAllQuestionRounds(hearingId, firstQuestionSummary, secondQuestionSummary);
 
         RestAssured.baseURI = "http://localhost:" + applicationPort;
@@ -23,6 +29,7 @@ public class ListQuestionsTest extends BaseIntegrationTest {
                 .get("/continuous-online-hearings/" + hearingId)
                 .then()
                 .statusCode(HttpStatus.OK.value())
+                .body("deadline_expiry_date", equalTo(deadlineExpiryDate))
                 .body("questions[0].question_id", equalTo(firstQuestionSummary.getQuestionId()))
                 .body("questions[0].question_header_text", equalTo(firstQuestionSummary.getQuestionHeaderText()))
                 .body("questions[0].answer_state", equalTo("draft"))

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/CohQuestionReference.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/CohQuestionReference.java
@@ -1,22 +1,20 @@
 package uk.gov.hmcts.reform.sscscorbackend.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.time.LocalDateTime;
 import java.util.List;
 
 public class CohQuestionReference {
     private String questionId;
     private String questionHeaderText;
     private int questionOrdinal;
-    private LocalDateTime deadlineExpiryDate;
+    private String deadlineExpiryDate;
     private List<CohAnswer> answers;
 
     public CohQuestionReference(
             @JsonProperty(value = "question_id") String questionId,
             @JsonProperty(value = "question_ordinal") int questionOrdinal,
             @JsonProperty(value = "question_header_text") String questionHeaderText,
-            @JsonProperty(value = "deadline_expiry_date") LocalDateTime deadlineExpiryDate,
+            @JsonProperty(value = "deadline_expiry_date") String deadlineExpiryDate,
             @JsonProperty(value = "answers") List<CohAnswer> answers
     ) {
         this.questionId = questionId;
@@ -38,7 +36,7 @@ public class CohQuestionReference {
         return questionHeaderText;
     }
 
-    public LocalDateTime getDeadlineExpiryDate() {
+    public String getDeadlineExpiryDate() {
         return deadlineExpiryDate;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/QuestionRound.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/QuestionRound.java
@@ -3,17 +3,15 @@ package uk.gov.hmcts.reform.sscscorbackend.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.time.LocalDateTime;
 import java.util.List;
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class QuestionRound {
     private List<QuestionSummary> questions;
-    private final LocalDateTime deadlineExpiryDate;
+    private final String deadlineExpiryDate;
 
-    public QuestionRound(List<QuestionSummary> questions, LocalDateTime deadlineExpiryDate) {
+    public QuestionRound(List<QuestionSummary> questions, String deadlineExpiryDate) {
         this.questions = questions;
         this.deadlineExpiryDate = deadlineExpiryDate;
     }
@@ -24,7 +22,7 @@ public class QuestionRound {
     }
 
     @JsonProperty(value = "deadline_expiry_date")
-    public LocalDateTime getDeadlineExpiryDate() {
+    public String getDeadlineExpiryDate() {
         return deadlineExpiryDate;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
@@ -4,7 +4,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
-import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,7 +70,7 @@ public class QuestionService {
 
         int currentQuestionRoundNumber = questionRounds.getCurrentQuestionRound();
         CohQuestionRound currentQuestionRound = questionRounds.getCohQuestionRound().get(currentQuestionRoundNumber - 1);
-        LocalDateTime deadlineExpiryDate = getQuestionRoundDeadlineExpiryDate(currentQuestionRound);
+        String deadlineExpiryDate = getQuestionRoundDeadlineExpiryDate(currentQuestionRound);
         List<QuestionSummary> questions = currentQuestionRound.getQuestionReferences().stream()
                 .sorted(Comparator.comparing(CohQuestionReference::getQuestionOrdinal))
                 .map(this::createQuestionSummary)
@@ -80,7 +79,7 @@ public class QuestionService {
         return new QuestionRound(questions, deadlineExpiryDate);
     }
 
-    private LocalDateTime getQuestionRoundDeadlineExpiryDate(CohQuestionRound questionRound) {
+    private String getQuestionRoundDeadlineExpiryDate(CohQuestionRound questionRound) {
         List<CohQuestionReference> questionRefsForRound = questionRound.getQuestionReferences();
         if (questionRefsForRound != null && !questionRefsForRound.isEmpty()) {
             return questionRound.getQuestionReferences().get(0).getDeadlineExpiryDate();

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -1,10 +1,11 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
+import static java.time.LocalDateTime.now;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.util.Collections.singletonList;
 import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.draft;
 import static uk.gov.hmcts.reform.sscscorbackend.service.onlinehearing.PanelRoleCoh.*;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,7 +23,7 @@ public class DataFixtures {
     private DataFixtures() {}
 
     public static QuestionRound someQuestionRound() {
-        return new QuestionRound(someQuestionSummaries(), LocalDateTime.now().plusDays(7));
+        return new QuestionRound(someQuestionSummaries(), now().plusDays(7).format(ISO_LOCAL_DATE_TIME));
     }
 
     public static List<QuestionSummary> someQuestionSummaries() {
@@ -51,8 +52,8 @@ public class DataFixtures {
 
     public static CohQuestionRounds someCohQuestionRoundsWithSingleRoundOfQuestions() {
         List<CohQuestionReference> cohQuestionReferenceList = Arrays.asList(
-                new CohQuestionReference("someQuestionId1", 1, "first question", LocalDateTime.now().plusDays(7), someCohAnswers("answer_drafted")),
-                new CohQuestionReference("someQuestionId2", 2, "second question", LocalDateTime.now().plusDays(10), someCohAnswers("answer_drafted"))
+                new CohQuestionReference("someQuestionId1", 1, "first question", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted")),
+                new CohQuestionReference("someQuestionId2", 2, "second question", now().plusDays(10).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))
         );
         return new CohQuestionRounds(1, singletonList(new CohQuestionRound(cohQuestionReferenceList)));
     }
@@ -60,9 +61,9 @@ public class DataFixtures {
     public static CohQuestionRounds someCohQuestionRoundsMultipleRoundsOfQuestions() {
         return new CohQuestionRounds(2, Arrays.asList(
                 new CohQuestionRound(singletonList(
-                        new CohQuestionReference("someQuestionId", 1, "first round question", LocalDateTime.now().plusDays(7), someCohAnswers("answer_drafted")))),
+                        new CohQuestionReference("someQuestionId", 1, "first round question", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted")))),
                 new CohQuestionRound(singletonList(
-                        new CohQuestionReference("someOtherQuestionId", 1, "second round question", LocalDateTime.now().plusDays(7), someCohAnswers("answer_drafted"))))
+                        new CohQuestionReference("someOtherQuestionId", 1, "second round question", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))))
         ));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
@@ -1,18 +1,17 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
+import static java.time.LocalDateTime.now;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.*;
 import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,7 +61,6 @@ public class QuestionServiceTest {
                 .getQuestionReferences().get(0);
         CohQuestionReference cohQuestion2Reference = cohQuestionRounds.getCohQuestionRound().get(0)
                 .getQuestionReferences().get(1);
-        LocalDateTime question2DeadlineExpiryDate = cohQuestion2Reference.getDeadlineExpiryDate();
         when(cohService.getQuestionRounds(onlineHearingId)).thenReturn(cohQuestionRounds);
         QuestionRound questionRound = underTest.getQuestions(onlineHearingId);
 
@@ -74,7 +72,7 @@ public class QuestionServiceTest {
     public void getsAListOfQuestionsWithUnansweredStatesWhenTheQuestionHasNotBeenAnswered() {
         CohQuestionRounds cohQuestionRounds = new CohQuestionRounds(1, singletonList(
                 new CohQuestionRound(singletonList(
-                        new CohQuestionReference("someQuestionId", 1, "first question", LocalDateTime.now().plusDays(7), null)
+                        new CohQuestionReference("someQuestionId", 1, "first question", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), null)
                 ))
         ));
         CohQuestionReference cohQuestionReference = cohQuestionRounds.getCohQuestionRound().get(0)
@@ -109,8 +107,8 @@ public class QuestionServiceTest {
     @Test
     public void getsAListOfQuestionsInTheCorrectOrderWhenTheyAreReturnedInTheIncorrectOrder() {
         CohQuestionRounds cohQuestionRounds = new CohQuestionRounds(1, singletonList(new CohQuestionRound(
-                asList(new CohQuestionReference("questionId2", 2, "second question", LocalDateTime.now().plusDays(7), someCohAnswers("answer_drafted")),
-                        new CohQuestionReference("questionId1", 1, "first question", LocalDateTime.now().plusDays(7), someCohAnswers("answer_drafted"))))
+                asList(new CohQuestionReference("questionId2", 2, "second question", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted")),
+                        new CohQuestionReference("questionId1", 1, "first question", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))))
         ));
         CohQuestionReference firstCohQuestionReference = cohQuestionRounds.getCohQuestionRound().get(0)
                 .getQuestionReferences().get(1);
@@ -212,8 +210,6 @@ public class QuestionServiceTest {
 
     @Test
     public void cannotSubmitAnswerThatHasNotAlreadyBeenAnswered() {
-        String answerId = "some-id";
-        String answer = "answer";
         when(cohService.getAnswers(onlineHearingId, questionId)).thenReturn(emptyList());
 
         boolean hasBeenSubmitted = underTest.submitAnswer(onlineHearingId, questionId);


### PR DESCRIPTION
For now we don't need to deal with these as dates so just pass the
String we get from COH. This is how question answer dates were
previously done.