### PR TITLE
[PREVIEW] SSCS-3589 Adding decision state date time to decision object

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohRequests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohRequests.java
@@ -64,7 +64,7 @@ public class CohRequests {
                 "{\"state_name\": \"question_issue_pending\"}"
         );
 
-        waitUntil(roundIssued(hearingId), 10L, "Question round has not been issues in 10 seconds.");
+        waitUntil(roundIssued(hearingId), 30L, "Question round has not been issued in 30 seconds.");
     }
 
     public String createAnswer(String hearingId, String questionId, String answerText) throws IOException {
@@ -103,7 +103,7 @@ public class CohRequests {
                         "}"
         );
 
-        waitUntil(decisionIssued(hearingId), 10L, "Decision has not been issues in 10 seconds.");
+        waitUntil(decisionIssued(hearingId), 30L, "Decision has not been issued in 30 seconds.");
     }
 
     public int getDeadlineExtensionCount(String hearingId) throws IOException {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAnOnlineHearingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAnOnlineHearingTest.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
+
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -13,12 +15,17 @@ public class GetAnOnlineHearingTest extends BaseFunctionTest {
     private final String decisionHeader = "The decision";
     private final String decisionReason = "Decision reason";
     private final String decisionText = "The decision text";
-
-    @Test
-    public void getAnOnlineHearing() throws IOException {
+    
+    private String createRandomEmail() {
         int randomNumber = (int) (Math.random() * 10000000);
         String emailAddress = "test" + randomNumber + "@hmcts.net";
         System.out.println("emailAddress " + emailAddress);
+        return emailAddress;
+    }
+
+    @Test
+    public void getAnOnlineHearing() throws IOException {
+        String emailAddress = createRandomEmail();
         String caseId = sscsCorBackendRequests.createCase(emailAddress);
         String expectedOnlineHearingId = cohRequests.createHearing(caseId);
 
@@ -32,15 +39,13 @@ public class GetAnOnlineHearingTest extends BaseFunctionTest {
 
     @Test
     public void getAnOnlineHearingWithDecision() throws IOException, InterruptedException {
-        int randomNumber = (int) (Math.random() * 10000000);
-        String emailAddress = "test" + randomNumber + "@hmcts.net";
-        System.out.println("emailAddress " + emailAddress);
+        String emailAddress = createRandomEmail();
         String caseId = sscsCorBackendRequests.createCase(emailAddress);
         String expectedOnlineHearingId = cohRequests.createHearing(caseId);
         String questionId = cohRequests.createQuestion(expectedOnlineHearingId);
         cohRequests.issueQuestionRound(expectedOnlineHearingId);
-        String answerId = cohRequests.createAnswer(expectedOnlineHearingId, questionId, "Valid answer");
-        String decisionId = cohRequests.createDecision(expectedOnlineHearingId, decisionAward,
+        cohRequests.createAnswer(expectedOnlineHearingId, questionId, "Valid answer");
+        cohRequests.createDecision(expectedOnlineHearingId, decisionAward,
                 decisionHeader, decisionReason, decisionText);
         cohRequests.issueDecision(expectedOnlineHearingId, decisionAward,
                 decisionHeader, decisionReason, decisionText);
@@ -55,5 +60,6 @@ public class GetAnOnlineHearingTest extends BaseFunctionTest {
         assertThat(decision.getString("decision_reason"), is(decisionReason));
         assertThat(decision.getString("decision_text"), is(decisionText));
         assertThat(decision.getString("decision_state"), is("decision_issued"));
+        assertThat(decision.getString("decision_state_datetime"), is(notNullValue()));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/OnlineHearingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/OnlineHearingTest.java
@@ -55,6 +55,7 @@ public class OnlineHearingTest extends BaseIntegrationTest {
                 .body("decision.decision_header", equalTo("Tribunal's final decision"))
                 .body("decision.decision_reason", equalTo("The decision reason"))
                 .body("decision.decision_text", equalTo("Some text about the decision"))
-                .body("decision.decision_state", equalTo("decision_issued"));
+                .body("decision.decision_state", equalTo("decision_issued"))
+                .body("decision.decision_state_datetime", equalTo("2018-10-05T09:36:33Z"));
     }
 }

--- a/src/integrationTest/resources/json/get_decision.json
+++ b/src/integrationTest/resources/json/get_decision.json
@@ -16,8 +16,8 @@
     }
   ],
   "decision_state": {
-    "state_datetime": "string",
-    "state_desc": "string",
+    "state_datetime": "2018-10-05T09:36:33Z",
+    "state_desc": "Decision Issued",
     "state_name": "decision_issued"
   },
   "decision_text": "Some text about the decision",

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/Decision.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/Decision.java
@@ -17,28 +17,31 @@ public class Decision {
     private final String decisionReason;
     private final String decisionText;
     private final String decisionState;
+    private final String decisionStateDateTime;
 
     public Decision(String onlineHearingId,
                     String decisionAward,
                     String decisionHeader,
                     String decisionReason,
                     String decisionText,
-                    String decisionState) {
+                    String decisionState,
+                    String decisionStateDateTime) {
         this.onlineHearingId = onlineHearingId;
         this.decisionAward = decisionAward;
         this.decisionHeader = decisionHeader;
         this.decisionReason = decisionReason;
         this.decisionText = decisionText;
         this.decisionState = decisionState;
+        this.decisionStateDateTime = decisionStateDateTime;
     }
 
-    @ApiModelProperty(example = "FINAL", required = true)
+    @ApiModelProperty(example = "appeal-upheld", required = true)
     @JsonProperty(value = "decision_award")
     public String getDecisionAward() {
         return decisionAward;
     }
 
-    @ApiModelProperty(example = "Decision header", required = true)
+    @ApiModelProperty(example = "appeal-upheld", required = true)
     @JsonProperty(value = "decision_header")
     public String getDecisionHeader() {
         return decisionHeader;
@@ -62,6 +65,12 @@ public class Decision {
         return decisionState;
     }
 
+    @ApiModelProperty(example = "2018-10-05T09:36:33Z", required = true)
+    @JsonProperty(value = "decision_state_datetime")
+    public String getDecisionStateDateTime() {
+        return decisionStateDateTime;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -76,7 +85,8 @@ public class Decision {
                 Objects.equals(decisionHeader, decision.decisionHeader) &&
                 Objects.equals(decisionReason, decision.decisionReason) &&
                 Objects.equals(decisionText, decision.decisionText) &&
-                Objects.equals(decisionState, decision.decisionState);
+                Objects.equals(decisionState, decision.decisionState) &&
+                Objects.equals(decisionStateDateTime, decision.decisionStateDateTime);
     }
 
     @Override
@@ -93,6 +103,7 @@ public class Decision {
                 ", decisionReason='" + decisionReason + '\'' +
                 ", decisionText='" + decisionText + '\'' +
                 ", decisionState='" + decisionState + '\'' +
+                ", decisionStateDateTime='" + decisionStateDateTime + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
@@ -68,7 +68,8 @@ public class OnlineHearingService {
         Optional<CohDecision> decision = cohClient.getDecision(onlineHearingId);
         return decision.map(d -> new Decision(onlineHearingId, d.getDecisionAward(),
                     d.getDecisionHeader(), d.getDecisionReason(),
-                    d.getDecisionText(), d.getCurrentDecisionState().getStateName()))
+                    d.getDecisionText(), d.getCurrentDecisionState().getStateName(),
+                    d.getCurrentDecisionState().getStateDateTime()))
                 .orElse(null);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -86,7 +86,7 @@ public class DataFixtures {
     }
 
     public static OnlineHearing someOnlineHearingWithDecision() {
-        Decision decision = new Decision("someOnlineHearingId", "decisionAward", "decisionHeader", "decisionReason", "decisionText", "decision_issued");
+        Decision decision = new Decision("someOnlineHearingId", "decisionAward", "decisionHeader", "decisionReason", "decisionText", "decision_issued", now().format(ISO_LOCAL_DATE_TIME));
         return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", decision);
     }
 }


### PR DESCRIPTION
* this is used by the frontend to determine the date by which the appellant should accept the tribunal's view