### PR TITLE
[PREVIEW] SSCS-3688 Appellant response to Tribunal's view

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscscorbackend;
 
 import static org.apache.http.conn.ssl.SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER;
 
+import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -20,6 +21,11 @@ public abstract class BaseFunctionTest {
     private CloseableHttpClient client;
     private HttpClient cohClient;
 
+    protected final String decisionAward = "appeal-upheld";
+    protected final String decisionHeader = "appeal-upheld";
+    protected final String decisionReason = "Decision reason";
+    protected final String decisionText = "Decision reason";
+
     protected SscsCorBackendRequests sscsCorBackendRequests;
     protected CohRequests cohRequests;
 
@@ -36,6 +42,30 @@ public abstract class BaseFunctionTest {
         String emailAddress = "test" + randomNumber + "@hmcts.net";
         System.out.println("emailAddress " + emailAddress);
         return emailAddress;
+    }
+
+    protected OnlineHearing createHearingWithQuestion(boolean ccdCaseRequired) throws IOException, InterruptedException {
+        String hearingId;
+        String emailAddress = null;
+        if (ccdCaseRequired) {
+            emailAddress = createRandomEmail();
+            String caseId = sscsCorBackendRequests.createCase(emailAddress);
+            hearingId = cohRequests.createHearing(caseId);
+        } else {
+            hearingId = cohRequests.createHearing();
+        }
+        String questionId = cohRequests.createQuestion(hearingId);
+        cohRequests.issueQuestionRound(hearingId);
+        return new OnlineHearing(emailAddress, hearingId, questionId);
+    }
+
+    protected void answerQuestion(String hearingId, String questionId) throws IOException {
+        cohRequests.createAnswer(hearingId, questionId, "Valid answer");
+    }
+
+    protected void createAndIssueDecision(String hearingId) throws IOException, InterruptedException {
+        cohRequests.createDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
+        cohRequests.issueDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
     }
 
     private CloseableHttpClient buildClient(String proxySystemProperty) throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
@@ -31,6 +31,13 @@ public abstract class BaseFunctionTest {
         cohRequests = new CohRequests(cohBaseUrl, cohClient);
     }
 
+    protected String createRandomEmail() {
+        int randomNumber = (int) (Math.random() * 10000000);
+        String emailAddress = "test" + randomNumber + "@hmcts.net";
+        System.out.println("emailAddress " + emailAddress);
+        return emailAddress;
+    }
+
     private CloseableHttpClient buildClient(String proxySystemProperty) throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
         SSLContextBuilder builder = new SSLContextBuilder();
         builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohRequests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohRequests.java
@@ -113,6 +113,11 @@ public class CohRequests {
         return deadlineExtensionCount;
     }
 
+    public JSONObject getDecisionReplies(String hearingId) throws IOException {
+        String url = cohBaseUrl + "/continuous-online-hearings/" + hearingId + "/decisionreplies";
+        return makeGetRequest(cohClient, url, null);
+    }
+
     private Supplier<Boolean> roundIssued(String hearingId) {
         return () -> {
             try {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/ExtendQuestionRoundDeadlineTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/ExtendQuestionRoundDeadlineTest.java
@@ -14,16 +14,14 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class ExtendQuestionRoundDeadlineTest extends BaseFunctionTest {
     @Test
     public void extendsTheQuestionRoundDeadlineDate() throws IOException, InterruptedException {
-        String hearingId = cohRequests.createHearing();
-        cohRequests.createQuestion(hearingId);
-        cohRequests.issueQuestionRound(hearingId);
+        OnlineHearing onlineHearing = createHearingWithQuestion(false);
 
-        JSONObject questionRound = sscsCorBackendRequests.extendQuestionRoundDeadline(hearingId);
+        JSONObject questionRound = sscsCorBackendRequests.extendQuestionRoundDeadline(onlineHearing.getHearingId());
         String deadlineExpiryDate = questionRound.getString("deadline_expiry_date");
 
         assertThat(deadlineExpiryDate, is(notNullValue()));
 
-        int deadlineExtensionCount = cohRequests.getDeadlineExtensionCount(hearingId);
+        int deadlineExtensionCount = cohRequests.getDeadlineExtensionCount(onlineHearing.getHearingId());
 
         assertThat(deadlineExtensionCount, is(1));
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAQuestionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAQuestionTest.java
@@ -14,11 +14,9 @@ public class GetAQuestionTest extends BaseFunctionTest {
 
     @Test
     public void getsAndAnswersAQuestion() throws IOException, InterruptedException {
-        String hearingId = cohRequests.createHearing();
-        String questionId = cohRequests.createQuestion(hearingId);
-        cohRequests.issueQuestionRound(hearingId);
+        OnlineHearing onlineHearing = createHearingWithQuestion(false);
 
-        JSONObject jsonObject = sscsCorBackendRequests.getQuestion(hearingId, questionId);
+        JSONObject jsonObject = sscsCorBackendRequests.getQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());
         String questionBodyText = jsonObject.getString("question_body_text");
         String answer = jsonObject.optString("answer", null);
 
@@ -26,16 +24,16 @@ public class GetAQuestionTest extends BaseFunctionTest {
         assertThat(answer, is(nullValue()));
 
         String expectedAnswer = "an answer";
-        sscsCorBackendRequests.answerQuestion(hearingId, questionId, expectedAnswer);
+        sscsCorBackendRequests.answerQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId(), expectedAnswer);
 
-        jsonObject = sscsCorBackendRequests.getQuestion(hearingId, questionId);
+        jsonObject = sscsCorBackendRequests.getQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());
         answer = jsonObject.optString("answer", expectedAnswer);
 
         assertThat(answer, is(expectedAnswer));
 
-        sscsCorBackendRequests.submitAnswer(hearingId, questionId);
+        sscsCorBackendRequests.submitAnswer(onlineHearing.getHearingId(), onlineHearing.getQuestionId());
 
-        JSONObject questionRound = sscsCorBackendRequests.getQuestions(hearingId);
+        JSONObject questionRound = sscsCorBackendRequests.getQuestions(onlineHearing.getHearingId());
         JSONArray questions = questionRound.getJSONArray("questions");
         assertThat(questions.getJSONObject(0).getString("answer_state"), is(submitted.name()));
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAnOnlineHearingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAnOnlineHearingTest.java
@@ -15,13 +15,6 @@ public class GetAnOnlineHearingTest extends BaseFunctionTest {
     private final String decisionHeader = "The decision";
     private final String decisionReason = "Decision reason";
     private final String decisionText = "The decision text";
-    
-    private String createRandomEmail() {
-        int randomNumber = (int) (Math.random() * 10000000);
-        String emailAddress = "test" + randomNumber + "@hmcts.net";
-        System.out.println("emailAddress " + emailAddress);
-        return emailAddress;
-    }
 
     @Test
     public void getAnOnlineHearing() throws IOException {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetListOfQuestionsTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetListOfQuestionsTest.java
@@ -13,15 +13,14 @@ import org.springframework.test.context.junit4.SpringRunner;
 @RunWith(SpringRunner.class)
 public class GetListOfQuestionsTest extends BaseFunctionTest {
     @Test
-    public void getAListOfQuestionTitles() throws IOException {
-        String hearingId = cohRequests.createHearing();
-        String questionId = cohRequests.createQuestion(hearingId);
+    public void getAListOfQuestionTitles() throws IOException, InterruptedException {
+        OnlineHearing onlineHearing = createHearingWithQuestion(false);
 
-        JSONObject questionRound = sscsCorBackendRequests.getQuestions(hearingId);
+        JSONObject questionRound = sscsCorBackendRequests.getQuestions(onlineHearing.getHearingId());
         JSONArray questions = questionRound.getJSONArray("questions");
 
         assertThat(questions.length(), is(1));
         assertThat(questions.getJSONObject(0).getString("question_header_text"), is("question header"));
-        assertThat(questions.getJSONObject(0).getString("question_id"), is(questionId));
+        assertThat(questions.getJSONObject(0).getString("question_id"), is(onlineHearing.getQuestionId()));
     }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/OnlineHearing.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/OnlineHearing.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.sscscorbackend;
+
+public class OnlineHearing {
+    private String emailAddress;
+    private String hearingId;
+    private String questionId;
+
+    public OnlineHearing(String emailAddress, String hearingId, String questionId) {
+        this.emailAddress = emailAddress;
+        this.hearingId = hearingId;
+        this.questionId = questionId;
+    }
+
+    public String getEmailAddress() {
+        return emailAddress;
+    }
+
+    public void setEmailAddress(String emailAddress) {
+        this.emailAddress = emailAddress;
+    }
+
+    public String getHearingId() {
+        return hearingId;
+    }
+
+    public void setHearingId(String hearingId) {
+        this.hearingId = hearingId;
+    }
+
+    public String getQuestionId() {
+        return questionId;
+    }
+
+    public void setQuestionId(String questionId) {
+        this.questionId = questionId;
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/RecordTribunalViewResponseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/RecordTribunalViewResponseTest.java
@@ -1,60 +1,46 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
-import org.json.JSONObject;
-import org.junit.Test;
-import java.io.IOException;
-
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
+import java.io.IOException;
+import org.json.JSONObject;
+import org.junit.Test;
+
 public class RecordTribunalViewResponseTest extends BaseFunctionTest {
-    private final String decisionAward = "FINAL";
-    private final String decisionHeader = "The decision";
-    private final String decisionReason = "Decision reason";
-    private final String decisionText = "The decision text";
 
     @Test
     public void recordAcceptedResponse() throws IOException, InterruptedException {
-        String emailAddress = createRandomEmail();
-        String caseId = sscsCorBackendRequests.createCase(emailAddress);
-        String hearingId = cohRequests.createHearing(caseId);
-        String questionId = cohRequests.createQuestion(hearingId);
-        cohRequests.issueQuestionRound(hearingId);
-        cohRequests.createAnswer(hearingId, questionId, "Valid answer");
-        cohRequests.createDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
-        cohRequests.issueDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
+        OnlineHearing onlineHearing = createHearingWithQuestion(true);
+        answerQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());
+        createAndIssueDecision(onlineHearing.getHearingId());
 
         String reply = "decision_accepted";
         String reason = "";
-        String cohExpectedReason = "decision_accepted";
 
-        sscsCorBackendRequests.recordTribunalViewResponse(hearingId, reply, reason);
-        JSONObject decisionRepliesJson = cohRequests.getDecisionReplies(hearingId);
+        sscsCorBackendRequests.recordTribunalViewResponse(onlineHearing.getHearingId(), reply, reason);
+        JSONObject decisionRepliesJson = cohRequests.getDecisionReplies(onlineHearing.getHearingId());
         int decisionReplyCount = decisionRepliesJson.getJSONArray("decision_replies").length();
         JSONObject firstDecisionReply = decisionRepliesJson.getJSONArray("decision_replies").getJSONObject(0);
 
         assertThat(decisionReplyCount, is(1));
         assertThat(firstDecisionReply.getString("decision_reply"), is(reply));
         // COH won't accept an empty reason, therefore it is set to the reply if it's empty
+        String cohExpectedReason = "decision_accepted";
         assertThat(firstDecisionReply.getString("decision_reply_reason"), is(cohExpectedReason));
     }
 
     @Test
     public void recordRejectedResponse() throws IOException, InterruptedException {
-        String emailAddress = createRandomEmail();
-        String caseId = sscsCorBackendRequests.createCase(emailAddress);
-        String hearingId = cohRequests.createHearing(caseId);
-        String questionId = cohRequests.createQuestion(hearingId);
-        cohRequests.issueQuestionRound(hearingId);
-        cohRequests.createAnswer(hearingId, questionId, "Valid answer");
-        cohRequests.createDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
-        cohRequests.issueDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
+        OnlineHearing onlineHearing = createHearingWithQuestion(true);
+        answerQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());
+        createAndIssueDecision(onlineHearing.getHearingId());
 
         String reply = "decision_rejected";
         String reason = "I reject this view because...";
 
-        sscsCorBackendRequests.recordTribunalViewResponse(hearingId, reply, reason);
-        JSONObject decisionRepliesJson = cohRequests.getDecisionReplies(hearingId);
+        sscsCorBackendRequests.recordTribunalViewResponse(onlineHearing.getHearingId(), reply, reason);
+        JSONObject decisionRepliesJson = cohRequests.getDecisionReplies(onlineHearing.getHearingId());
         int decisionReplyCount = decisionRepliesJson.getJSONArray("decision_replies").length();
         JSONObject firstDecisionReply = decisionRepliesJson.getJSONArray("decision_replies").getJSONObject(0);
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/RecordTribunalViewResponseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/RecordTribunalViewResponseTest.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.reform.sscscorbackend;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import java.io.IOException;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class RecordTribunalViewResponseTest extends BaseFunctionTest {
+    private final String decisionAward = "FINAL";
+    private final String decisionHeader = "The decision";
+    private final String decisionReason = "Decision reason";
+    private final String decisionText = "The decision text";
+
+    @Test
+    public void recordAcceptedResponse() throws IOException, InterruptedException {
+        String emailAddress = createRandomEmail();
+        String caseId = sscsCorBackendRequests.createCase(emailAddress);
+        String hearingId = cohRequests.createHearing(caseId);
+        String questionId = cohRequests.createQuestion(hearingId);
+        cohRequests.issueQuestionRound(hearingId);
+        cohRequests.createAnswer(hearingId, questionId, "Valid answer");
+        cohRequests.createDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
+        cohRequests.issueDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
+
+        String reply = "decision_accepted";
+        String reason = "";
+        String cohExpectedReason = "decision_accepted";
+
+        sscsCorBackendRequests.recordTribunalViewResponse(hearingId, reply, reason);
+        JSONObject decisionRepliesJson = cohRequests.getDecisionReplies(hearingId);
+        int decisionReplyCount = decisionRepliesJson.getJSONArray("decision_replies").length();
+        JSONObject firstDecisionReply = decisionRepliesJson.getJSONArray("decision_replies").getJSONObject(0);
+
+        assertThat(decisionReplyCount, is(1));
+        assertThat(firstDecisionReply.getString("decision_reply"), is(reply));
+        // COH won't accept an empty reason, therefore it is set to the reply if it's empty
+        assertThat(firstDecisionReply.getString("decision_reply_reason"), is(cohExpectedReason));
+    }
+
+    @Test
+    public void recordRejectedResponse() throws IOException, InterruptedException {
+        String emailAddress = createRandomEmail();
+        String caseId = sscsCorBackendRequests.createCase(emailAddress);
+        String hearingId = cohRequests.createHearing(caseId);
+        String questionId = cohRequests.createQuestion(hearingId);
+        cohRequests.issueQuestionRound(hearingId);
+        cohRequests.createAnswer(hearingId, questionId, "Valid answer");
+        cohRequests.createDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
+        cohRequests.issueDecision(hearingId, decisionAward, decisionHeader, decisionReason, decisionText);
+
+        String reply = "decision_rejected";
+        String reason = "I reject this view because...";
+
+        sscsCorBackendRequests.recordTribunalViewResponse(hearingId, reply, reason);
+        JSONObject decisionRepliesJson = cohRequests.getDecisionReplies(hearingId);
+        int decisionReplyCount = decisionRepliesJson.getJSONArray("decision_replies").length();
+        JSONObject firstDecisionReply = decisionRepliesJson.getJSONArray("decision_replies").getJSONObject(0);
+
+        assertThat(decisionReplyCount, is(1));
+        assertThat(firstDecisionReply.getString("decision_reply"), is(reply));
+        assertThat(firstDecisionReply.getString("decision_reply_reason"), is(reason));
+    }
+}

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/SscsCorBackendRequests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/SscsCorBackendRequests.java
@@ -94,4 +94,11 @@ public class SscsCorBackendRequests {
 
         return new JSONObject(responseBody);
     }
+
+    public void recordTribunalViewResponse(String hearingId, String reply, String reason) throws IOException {
+        HttpResponse response = client.execute(patch(baseUrl + "/continuous-online-hearings/" + hearingId + "/tribunal-view")
+                .setEntity(new StringEntity("{\"reply\":\"" + reply + "\", \"reason\":\"" + reason + "\"}", APPLICATION_JSON))
+                .build());
+        assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.NO_CONTENT.value()));
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohStub.java
@@ -291,4 +291,20 @@ public class CohStub extends BaseStub {
                 )
         );
     }
+
+    public void stubPostDecisionReply(String hearingId, String reply, String reason) {
+        // COH won't accept an empty reason, therefore it is set to the reply if it's empty
+        if (reason.isEmpty()) {
+            reason = reply;
+        }
+        wireMock.stubFor(post("/continuous-online-hearings/" + hearingId + "/decisionreplies")
+                .withHeader("ServiceAuthorization", new RegexPattern(".*"))
+                .withRequestBody(equalToJson("{\"decision_reply\":\"" + reply + "\", \"decision_reply_reason\":\"" + reason + "\"}"))
+                .willReturn(status(201)
+                    .withBody("{\n" +
+                            "  \"decision_reply_id\": \"123\"\n" +
+                            "}")
+                )
+        );
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/RecordTribunalViewResponseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/RecordTribunalViewResponseTest.java
@@ -1,0 +1,62 @@
+package uk.gov.hmcts.reform.sscscorbackend;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import io.restassured.RestAssured;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RecordTribunalViewResponseTest extends BaseIntegrationTest {
+
+    @Test
+    public void recordAcceptedResponse() {
+        String hearingId = "1";
+        String reply = "decision_accepted";
+        String reason = "";
+        cohStub.stubPostDecisionReply(hearingId, reply, reason);
+        RestAssured.baseURI = "http://localhost:" + applicationPort;
+        RestAssured.given()
+                .body("{\"reply\":\"" + reply + "\", \"reason\":\"" + reason + "\"}")
+                .when()
+                .contentType(APPLICATION_JSON_VALUE)
+                .patch("/continuous-online-hearings/" + hearingId + "/tribunal-view")
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    public void recordRejectedResponse() {
+        String hearingId = "1";
+        String reply = "decision_rejected";
+        String reason = "Reasons for rejecting tribunal's view";
+        cohStub.stubPostDecisionReply(hearingId, reply, reason);
+        RestAssured.baseURI = "http://localhost:" + applicationPort;
+        RestAssured.given()
+                .body("{\"reply\":\"" + reply + "\", \"reason\":\"" + reason + "\"}")
+                .when()
+                .contentType(APPLICATION_JSON_VALUE)
+                .patch("/continuous-online-hearings/" + hearingId + "/tribunal-view")
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    public void recordRejectedResponseWithoutReason() {
+        String hearingId = "1";
+        String reply = "decision_rejected";
+        String reason = "";
+        RestAssured.baseURI = "http://localhost:" + applicationPort;
+        RestAssured.given()
+                .body("{\"reply\":\"" + reply + "\", \"reason\":\"" + reason + "\"}")
+                .when()
+                .contentType(APPLICATION_JSON_VALUE)
+                .patch("/continuous-online-hearings/" + hearingId + "/tribunal-view")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/TribunalViewController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/TribunalViewController.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import uk.gov.hmcts.reform.sscscorbackend.domain.*;
+import uk.gov.hmcts.reform.sscscorbackend.service.OnlineHearingService;
+
+@RestController
+@RequestMapping("/continuous-online-hearings")
+public class TribunalViewController {
+    private final OnlineHearingService onlineHearingService;
+
+    public TribunalViewController(@Autowired OnlineHearingService onlineHearingService) {
+        this.onlineHearingService = onlineHearingService;
+    }
+
+    @ApiOperation(value = "Appellant response to tribunal's view",
+            notes = "Accepted or rejected with reasons"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "Response recorded"),
+            @ApiResponse(code = 400, message = "Missing reason for decision_rejected reply")
+    })
+    @RequestMapping(method = RequestMethod.PATCH, value = "{onlineHearingId}/tribunal-view")
+    @ResponseStatus(value = HttpStatus.NO_CONTENT)
+    public ResponseEntity<Void> recordTribunalViewResponse(@PathVariable String onlineHearingId,
+                                                           @RequestBody TribunalViewResponse tribunalViewResponse) {
+        if (tribunalViewResponse.getReply().equals("decision_rejected") && tribunalViewResponse.getReason().equals("")) {
+            return ResponseEntity.badRequest().build();
+        }
+        onlineHearingService.addDecisionReply(onlineHearingId, tribunalViewResponse);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/TribunalViewController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/TribunalViewController.java
@@ -30,8 +30,12 @@ public class TribunalViewController {
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> recordTribunalViewResponse(@PathVariable String onlineHearingId,
                                                            @RequestBody TribunalViewResponse tribunalViewResponse) {
-        if (tribunalViewResponse.getReply().equals("decision_rejected") && tribunalViewResponse.getReason().equals("")) {
+        if (tribunalViewResponse.getReply().equals("decision_rejected") && tribunalViewResponse.getReason().isEmpty()) {
             return ResponseEntity.badRequest().build();
+        }
+        // COH won't accept an empty reason, therefore set the reason to the reply if it's empty
+        if (tribunalViewResponse.getReason().isEmpty()) {
+            tribunalViewResponse.setReason(tribunalViewResponse.getReply());
         }
         onlineHearingService.addDecisionReply(onlineHearingId, tribunalViewResponse);
         return ResponseEntity.noContent().build();

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/CohDecisionReply.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/CohDecisionReply.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.sscscorbackend.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class CohDecisionReply {
+    private final String reply;
+    private final String replyReason;
+
+    public CohDecisionReply(String reply, String replyReason) {
+        this.reply = reply;
+        this.replyReason = replyReason;
+    }
+
+    @JsonProperty(value = "decision_reply")
+    public String getReply() {
+        return reply;
+    }
+
+    @JsonProperty(value = "decision_reply_reason")
+    public String getReplyReason() {
+        return replyReason;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CohDecisionReply that = (CohDecisionReply) o;
+        return Objects.equals(reply, that.reply) &&
+                Objects.equals(replyReason, that.replyReason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(reply, replyReason);
+    }
+
+    @Override
+    public String toString() {
+        return "CohDecisionReply{" +
+                "  reply='" + reply + '\'' +
+                ", replyReason='" + replyReason + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/TribunalViewResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/TribunalViewResponse.java
@@ -31,4 +31,8 @@ public class TribunalViewResponse {
     public String getReason() {
         return reason;
     }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/TribunalViewResponse.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/TribunalViewResponse.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.sscscorbackend.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TribunalViewResponse {
+
+    @ApiModelProperty(example = "decision_accepted", required = true)
+    @JsonProperty(value = "reply")
+    private String reply;
+
+    @ApiModelProperty(example = "This is a reason for the accept or reject", required = false)
+    @JsonProperty(value = "reason")
+    private String reason;
+
+    // needed for Jackson
+    private TribunalViewResponse() {
+    }
+
+    public TribunalViewResponse(String reply, String reason) {
+        this.reply = reply;
+        this.reason = reason;
+    }
+
+    public String getReply() {
+        return reply;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CohClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CohClient.java
@@ -85,4 +85,13 @@ public interface CohClient {
             @RequestHeader(AUTHORIZATION) String authorisation,
             @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
             @PathVariable("onlineHearingId") String onlineHearingId);
+
+    @RequestMapping(
+            method = RequestMethod.POST,
+            value = "/continuous-online-hearings/{onlineHearingId}/decisionreplies"
+    )
+    void addDecisionReply(@RequestHeader(AUTHORIZATION) String authorisation,
+                      @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
+                      @PathVariable("onlineHearingId") String onlineHearingId,
+                      @RequestBody CohDecisionReply decisionReply);
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CohService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CohService.java
@@ -68,4 +68,8 @@ public class CohService {
     public Optional<CohDecision> getDecision(String onlineHearingId) {
         return cohClient.getDecision(OAUTH2_TOKEN, authTokenGenerator.generate(), onlineHearingId);
     }
+
+    public void addDecisionReply(String onlineHearingId, CohDecisionReply decisionReply) {
+        cohClient.addDecisionReply(OAUTH2_TOKEN, authTokenGenerator.generate(), onlineHearingId, decisionReply);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
@@ -16,9 +16,11 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscscorbackend.domain.CohDecision;
+import uk.gov.hmcts.reform.sscscorbackend.domain.CohDecisionReply;
 import uk.gov.hmcts.reform.sscscorbackend.domain.CohOnlineHearings;
 import uk.gov.hmcts.reform.sscscorbackend.domain.Decision;
 import uk.gov.hmcts.reform.sscscorbackend.domain.OnlineHearing;
+import uk.gov.hmcts.reform.sscscorbackend.domain.TribunalViewResponse;
 import uk.gov.hmcts.reform.sscscorbackend.exception.RestResponseEntityExceptionHandler;
 import uk.gov.hmcts.reform.sscscorbackend.service.onlinehearing.CreateOnlineHearingRequest;
 
@@ -62,6 +64,11 @@ public class OnlineHearingService {
                 })
                 .reduce(checkThereIsOnlyOneCase())
                 .flatMap(getHearingFromCoh());
+    }
+
+    public void addDecisionReply(String onlineHearingId, TribunalViewResponse tribunalViewResponse) {
+        CohDecisionReply cohDecisionReply = new CohDecisionReply(tribunalViewResponse.getReply(), tribunalViewResponse.getReason());
+        cohClient.addDecisionReply(onlineHearingId, cohDecisionReply);
     }
 
     private Decision getDecision(String onlineHearingId) {

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/TribunalViewControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/TribunalViewControllerTest.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.reform.sscscorbackend.domain.TribunalViewResponse;
+import uk.gov.hmcts.reform.sscscorbackend.service.OnlineHearingService;
+
+public class TribunalViewControllerTest {
+    private String onlineHearingId;
+    private TribunalViewController underTest;
+    private OnlineHearingService onlineHearingService;
+
+    @Before
+    public void setUp() {
+        onlineHearingId = "someHearingId";
+        onlineHearingService = mock(OnlineHearingService.class);
+        underTest = new TribunalViewController(onlineHearingService);
+    }
+
+    @Test
+    public void recordTribunalViewResponse() {
+        TribunalViewResponse tribunalViewResponse = new TribunalViewResponse("accepted", "Reasons");
+        ResponseEntity response = underTest.recordTribunalViewResponse(onlineHearingId, tribunalViewResponse);
+
+        assertThat(response.getStatusCode(), is(HttpStatus.NO_CONTENT));
+        verify(onlineHearingService).addDecisionReply(onlineHearingId, tribunalViewResponse);
+    }
+}


### PR DESCRIPTION
Adding endpoint to record appellant response to tribunal's preliminary view

* accepts a reply and reason and maps that to a decision reply in COH
* a rejected reply must contain a reason

Moving some common code for functional tests into the base class 
* this includes things such as creating hearings/questions, issuing rounds/decisions etc