### PR TITLE
SSCS-4150 Amending Auth value in the COH requests within functional tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohRequests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohRequests.java
@@ -172,7 +172,7 @@ public class CohRequests {
 
     private static String makePostRequest(HttpClient client, String uri, String body, String responseValue) throws IOException {
         HttpResponse httpResponse = client.execute(post(uri)
-                .setHeader(HttpHeaders.AUTHORIZATION, "someValue")
+                .setHeader(HttpHeaders.AUTHORIZATION, "oauth2Token")
                 .setHeader("ServiceAuthorization", "someValue")
                 .setEntity(new StringEntity(body, APPLICATION_JSON))
                 .build());
@@ -185,7 +185,7 @@ public class CohRequests {
 
     private static void makePutRequest(HttpClient client, String uri, String body) throws IOException {
         HttpResponse httpResponse = client.execute(put(uri)
-                .setHeader(HttpHeaders.AUTHORIZATION, "someValue")
+                .setHeader(HttpHeaders.AUTHORIZATION, "oauth2Token")
                 .setHeader("ServiceAuthorization", "someValue")
                 .setEntity(new StringEntity(body, APPLICATION_JSON))
                 .build());
@@ -195,7 +195,7 @@ public class CohRequests {
 
     private static JSONObject makeGetRequest(HttpClient client, String uri, String responseValue) throws IOException {
         HttpResponse httpResponse = client.execute(get(uri)
-                .setHeader(HttpHeaders.AUTHORIZATION, "someValue")
+                .setHeader(HttpHeaders.AUTHORIZATION, "oauth2Token")
                 .setHeader("ServiceAuthorization", "someValue")
                 .setHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                 .build());


### PR DESCRIPTION
* this is due to the code checking the decision replies and filtering by author_reference
* the author reference is populated with the value of the Auth header
* for the tests to work is must be the same as when the frontend makes requests to add decision replied