### PR TITLE
Removed dependency on core-case-data-store-client jar. This dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,6 @@ dependencies {
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.0.1.RELEASE'
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.4'
 
-  compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.2.0'
   compileOnly 'org.projectlombok:lombok:1.18.2'
   compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.2.2.RELEASE'
   compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.4.0'
@@ -177,7 +176,6 @@ dependencies {
 
   integrationTestCompile "com.github.tomakehurst:wiremock:2.19.0"
   integrationTestCompile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
-  integrationTestCompile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.2.0'
 
   functionalTestCompile sourceSets.main.runtimeClasspath
   functionalTestCompile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured


### PR DESCRIPTION
should come in from sscs-common and not be directly set in our build.