### PR TITLE
SSCS-4206 Check evidence file type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/documentmanagement/IllegalFileTypeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/documentmanagement/IllegalFileTypeException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.sscscorbackend.service.documentmanagement;
+
+public class IllegalFileTypeException extends RuntimeException {
+    public IllegalFileTypeException(String fileName) {
+        super("File [" + fileName + "] cannot be uploaded to document store.");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadControllerTest.java
@@ -6,9 +6,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.reform.sscscorbackend.domain.Evidence;
 import uk.gov.hmcts.reform.sscscorbackend.service.EvidenceUploadService;
+import uk.gov.hmcts.reform.sscscorbackend.service.documentmanagement.IllegalFileTypeException;
 
 public class EvidenceUploadControllerTest {
 
@@ -58,6 +57,18 @@ public class EvidenceUploadControllerTest {
         );
 
         assertThat(evidenceResponseEntity.getStatusCode(), is(NOT_FOUND));
+    }
+
+    @Test
+    public void cannotUploadDocumentsThatDocumentStoreDoesNotSupport() {
+        MultipartFile file = mock(MultipartFile.class);
+        when(evidenceUploadService.uploadEvidence(someOnlineHearingId, someQuestionId, file)).thenThrow(new IllegalFileTypeException("someFile.bad"));
+
+        ResponseEntity<Evidence> evidenceResponseEntity = evidenceUploadController.uploadEvidence(
+                someOnlineHearingId, someQuestionId, file
+        );
+
+        assertThat(evidenceResponseEntity.getStatusCode(), is(UNPROCESSABLE_ENTITY));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/DocumentManagementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/DocumentManagementServiceTest.java
@@ -6,11 +6,14 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
 import uk.gov.hmcts.reform.sscscorbackend.service.documentmanagement.DocumentManagementClient;
 import uk.gov.hmcts.reform.sscscorbackend.service.documentmanagement.DocumentManagementService;
+import uk.gov.hmcts.reform.sscscorbackend.service.documentmanagement.IllegalFileTypeException;
 
 public class DocumentManagementServiceTest {
 
@@ -38,6 +41,13 @@ public class DocumentManagementServiceTest {
         documentManagementService.upload(files);
 
         verify(documentUploadClientApi).upload("oauth2Token", authToken, "sscs", files);
+    }
+
+    @Test(expected = IllegalFileTypeException.class)
+    public void throwsIllegalFileTypeExceptionIfDocumentStoreCannotStoreFile() {
+        when(documentUploadClientApi.upload(any(), any(), any(), any())).thenThrow(new HttpClientErrorException(HttpStatus.UNPROCESSABLE_ENTITY));
+
+        documentManagementService.upload(files);
     }
 
     @Test


### PR DESCRIPTION
We will restrict the file types the user can upload as evidence in the frontend but also the document
store can reject the file. Handle this and return 422 when the document type cannot be uploaded.