### PR TITLE
Do not build docker images on master only PR builds

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -29,7 +29,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withPipeline(type, product, component) {
     setVaultName('sscs')
     loadVaultSecrets(secrets)
-    enableDockerBuild()
+    onPR { enableDockerBuild() }
     enableDeployToAKS()
     enableSlackNotifications('#sscs-tech')
 }


### PR DESCRIPTION
The PR builds use an AKS environment to run their functional tests. We do not 
use this in AAT or prod and are not running the app locally with docker so do 
not need to build the image.