### PR TITLE
SSCS-4425 Fix file uploads

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,6 +4,10 @@ server:
 spring:
   application:
     name: SSCS-COR-Backend
+  servlet:
+    multipart:
+      max-file-size: ${MAX_FILE_SIZE:11MB}
+      max-request-size: ${MAX_FILE_SIZE:11MB}
 
 coh:
   url: ${COH_URL:http://localhost:8081}


### PR DESCRIPTION
Files over 1MB are getting rejected by the backend ad it is limited to
file uploads of 1MB. This is done with some config set it to 11MB which
is 1MB higher than the frontend allows so we do not reject files here
that the frontend has allowed.