### PR TITLE
Sscs-4093 handle case not setup

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionController.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.Answer;
 import uk.gov.hmcts.reform.sscscorbackend.domain.OnlineHearing;
 import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
 import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
+import uk.gov.hmcts.reform.sscscorbackend.service.CaseNotCorException;
 import uk.gov.hmcts.reform.sscscorbackend.service.OnlineHearingService;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 
@@ -37,6 +38,7 @@ public class QuestionController {
     )
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "No online hearing found for email address"),
+            @ApiResponse(code = 409, message = "Case found but it is not a COR case"),
             @ApiResponse(code = 422, message = "Multiple online hearings found for email address")
     })
     @RequestMapping(method = RequestMethod.GET)
@@ -48,8 +50,9 @@ public class QuestionController {
                     .orElse(ResponseEntity.notFound().build());
         } catch (IllegalStateException exc) {
             return ResponseEntity.unprocessableEntity().build();
+        } catch (CaseNotCorException exc) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
         }
-
     }
 
     @ApiOperation(value = "Get a list of questions",

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/QuestionRound.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/QuestionRound.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sscscorbackend.domain;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
 import java.util.List;
 
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
@@ -32,5 +33,9 @@ public class QuestionRound {
     @JsonProperty(value = "deadline_extension_count")
     public int getDeadlineExtensionCount() {
         return deadlineExtensionCount;
+    }
+
+    public static QuestionRound emptyQuestionRound() {
+        return new QuestionRound(Collections.emptyList(), null, 0);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CaseNotCorException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CaseNotCorException.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+public class CaseNotCorException extends RuntimeException {
+    public CaseNotCorException() {
+        super("Case was found but it is not a COR case");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
@@ -81,6 +81,10 @@ public class QuestionService {
         Map<String, List<Evidence>> evidencePerQuestion = evidenceUploadService.listEvidence(onlineHearingId);
 
         int currentQuestionRoundNumber = questionRounds.getCurrentQuestionRound();
+        if (currentQuestionRoundNumber == 0) {
+            return QuestionRound.emptyQuestionRound();
+        }
+
         CohQuestionRound currentQuestionRound = questionRounds.getCohQuestionRound().get(currentQuestionRoundNumber - 1);
         String deadlineExpiryDate = getQuestionRoundDeadlineExpiryDate(currentQuestionRound);
         int deadlineExtensionCount = currentQuestionRound.getDeadlineExtensionCount();

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -55,6 +55,10 @@ public class DataFixtures {
         return new CohQuestionRounds(1, singletonList(new CohQuestionRound(cohQuestionReferenceList, 0)));
     }
 
+    public static CohQuestionRounds someUnpublishedCohQuestionRounds() {
+        return new CohQuestionRounds(0, Collections.emptyList());
+    }
+
     public static CohQuestionRounds someCohQuestionRoundsMultipleRoundsOfQuestions() {
         return new CohQuestionRounds(2, Arrays.asList(
                 new CohQuestionRound(singletonList(

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionControllerTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.*;
 
-import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/QuestionControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.sscscorbackend.domain.*;
+import uk.gov.hmcts.reform.sscscorbackend.service.CaseNotCorException;
 import uk.gov.hmcts.reform.sscscorbackend.service.OnlineHearingService;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 
@@ -22,7 +23,6 @@ public class QuestionControllerTest {
     private String onlineHearingId;
     private String questionId;
     private QuestionController underTest;
-    private List<QuestionSummary> expectedQuestions;
     private QuestionRound questionRound;
     private OnlineHearingService onlineHearingService;
 
@@ -31,7 +31,6 @@ public class QuestionControllerTest {
         expectedQuestion = someQuestion();
         onlineHearingId = expectedQuestion.getOnlineHearingId();
         questionId = expectedQuestion.getQuestionId();
-        expectedQuestions = someQuestionSummaries();
         questionRound = someQuestionRound();
 
         questionService = mock(QuestionService.class);
@@ -84,6 +83,17 @@ public class QuestionControllerTest {
         ResponseEntity<OnlineHearing> onlineHearingResponse = underTest.getOnlineHearing(someEmailAddress);
 
         assertThat(onlineHearingResponse.getStatusCode(), is(HttpStatus.NOT_FOUND));
+    }
+
+    @Test
+    public void foundAHearingButItIsNotACorCase() {
+        String someEmailAddress = "someEmailAddress";
+        when(onlineHearingService.getOnlineHearing(someEmailAddress))
+                .thenThrow(new CaseNotCorException());
+
+        ResponseEntity<OnlineHearing> onlineHearingResponse = underTest.getOnlineHearing(someEmailAddress);
+
+        assertThat(onlineHearingResponse.getStatusCode(), is(HttpStatus.CONFLICT));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
@@ -114,6 +114,14 @@ public class OnlineHearingServiceTest {
         assertThat(onlineHearing.isPresent(), is(false));
     }
 
+    @Test(expected = CaseNotCorException.class)
+    public void noOnlineHearingIfFoundInCcdButNotAnOnlineResolutionAppeal() {
+        when(ccdService.findCaseBy(singletonMap("case.subscriptions.appellantSubscription.email", someEmailAddress), idamTokens))
+                .thenReturn(singletonList(createCaseDetails(someCaseId, "caseref", "firstname", "lastname", "paper")));
+
+        underTest.getOnlineHearing(someEmailAddress);
+    }
+
     @Test
     public void noOnlineHearingIfNotFoundInCOh() {
         when(ccdService.findCaseBy(singletonMap("case.subscriptions.appellantSubscription.email", someEmailAddress), idamTokens))
@@ -124,13 +132,17 @@ public class OnlineHearingServiceTest {
     }
 
     private SscsCaseDetails createCaseDetails(Long caseId, String expectedCaseReference, String firstName, String lastName) {
+        return createCaseDetails(caseId, expectedCaseReference, firstName, lastName, "cor");
+    }
+
+    private SscsCaseDetails createCaseDetails(Long caseId, String expectedCaseReference, String firstName, String lastName, String hearingType) {
         return SscsCaseDetails.builder()
                 .id(caseId)
                 .data(SscsCaseData.builder()
                         .caseReference(expectedCaseReference)
                         .onlinePanel(OnlinePanel.builder().assignedTo("someJudge").build())
                         .appeal(Appeal.builder()
-                                .hearingType("cor")
+                                .hearingType(hearingType)
                                 .appellant(Appellant.builder()
                                         .name(Name.builder()
                                                 .firstName(firstName)

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.*;
 import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.*;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +38,17 @@ public class QuestionServiceTest {
         cohAnswer = someCohAnswer();
         evidenceUploadService = mock(EvidenceUploadService.class);
         underTest = new QuestionService(cohService, evidenceUploadService);
+    }
+
+    @Test
+    public void getsAnEmptyListOfQuestionsWhenNoRoundsHaveBeenIssued() {
+        CohQuestionRounds cohQuestionRounds = someUnpublishedCohQuestionRounds();
+
+        when(cohService.getQuestionRounds(onlineHearingId)).thenReturn(cohQuestionRounds);
+        QuestionRound questionRound = underTest.getQuestions(onlineHearingId);
+        List<QuestionSummary> questions = questionRound.getQuestions();
+
+        assertThat(questions, is(Collections.emptyList()));
     }
 
     @Test


### PR DESCRIPTION

SSCS-4093 Handle not finding Cor case  …
We want to display useful messages to the user if they login to cor and
we cannot find a unique case for their user.

- Handle when we find a case/cases in CCD but they are not COR cases.
Return 409 to the frontend.
- Return empty list of questions if a online hearing has been created
but no question rounds have been issued