### PR TITLE
SSCS-4485 Add logging when evidence upload fails

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/documentmanagement/DocumentManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/documentmanagement/DocumentManagementService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend.service.documentmanagement;
 
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.document.DocumentUploadClientApi;
 import uk.gov.hmcts.reform.document.domain.UploadResponse;
 
+@Slf4j
 @Service
 public class DocumentManagementService {
     private static final String OAUTH2_TOKEN = "oauth2Token";
@@ -33,6 +35,7 @@ public class DocumentManagementService {
             return documentUploadClientApi.upload(OAUTH2_TOKEN, serviceAuthorization, USER_ID, files);
         } catch (HttpClientErrorException exc) {
             if (exc.getStatusCode().equals(HttpStatus.UNPROCESSABLE_ENTITY)) {
+                log.error("Cannot upload evidence [" + files.get(0).getName() + "]", exc);
                 throw new IllegalFileTypeException(files.get(0).getName());
             }
             throw exc;


### PR DESCRIPTION
This is to look into why tif files cannot be uploaded.