### PR TITLE
SSCS-4610 Get rid of robotics config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ dependencies {
   compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.4.1'
   compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.117'
 
-  compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-robotics-email-common', version: '0.0.86'
+  compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-robotics-email-common', version: '0.0.94'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '4.0.1'
 
   // Removed for now as we have an issue with some of its dependencies

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,13 +63,3 @@ appeal:
     to: ${EMAIL_TO:receiver@hmcts.net}
     subject: ${EMAIL_SUBJECT:Your appeal}
     message: ${EMAIL_MESSAGE:Your appeal has been created \nPlease do not respond to this email}
-
-robotics:
-  email:
-    from: ${ROBOTICS_EMAIL_FROM:sscs@hmcts.net}
-    to: ${ROBOTICS_EMAIL_TO:receiver@hmcts.net}
-    subject: ${ROBOTICS_EMAIL_SUBJECT:Robotics Data}
-    message: ${ROBOTICS_EMAIL_MESSAGE:Please find attached the robotics json file \nPlease do not respond to this email}
-  schema:
-    resource:
-      location: /schema/sscs-robotics.json


### PR DESCRIPTION
Have split the sscs-pdf-robotics-email-common module so it no longer
contains robotics code. Therefore we do not need to setup the robotics
stuff.