### PR TITLE
SSCS-4414 Appellant can see draft questions

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CohStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CohStub.java
@@ -52,7 +52,8 @@ public class CohStub extends BaseStub {
             "    \"question_rounds\": [\n" +
             "        {\n" +
             "            \"question_round_number\": \"1\",\n" +
-            "            \"question_references\": {question_references}\n" +
+            "            \"question_references\": {question_references},\n" +
+            "            \"question_round_state\": { \"state_name\": \"question_issued\" }\n" +
             "        }\n" +
             "    ]\n" +
             "}";

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
@@ -91,6 +91,11 @@ public class QuestionService {
         }
 
         CohQuestionRound currentQuestionRound = questionRounds.getCohQuestionRound().get(currentQuestionRoundNumber - 1);
+        String currentQuestionRoundState = currentQuestionRound.getQuestionRoundState().getStateName();
+        if ("question_drafted".equals(currentQuestionRoundState) || "question_issue_pending".equals(currentQuestionRoundState)) {
+            return  QuestionRound.emptyQuestionRound();
+        }
+
         String deadlineExpiryDate = getQuestionRoundDeadlineExpiryDate(currentQuestionRound);
         int deadlineExtensionCount = currentQuestionRound.getDeadlineExtensionCount();
         List<QuestionSummary> questions = currentQuestionRound.getQuestionReferences().stream()

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/coh/api/CohQuestionRound.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/coh/api/CohQuestionRound.java
@@ -6,11 +6,14 @@ import java.util.List;
 public class CohQuestionRound {
     private List<CohQuestionReference> questionReferences;
     private int deadlineExtensionCount;
+    private CohState questionRoundState;
 
     public CohQuestionRound(@JsonProperty(value = "question_references") List<CohQuestionReference> questionReferences,
-                            @JsonProperty(value = "deadline_extension_count") int deadlineExtensionCount) {
+                            @JsonProperty(value = "deadline_extension_count") int deadlineExtensionCount,
+                            @JsonProperty(value = "question_round_state")  CohState questionRoundState) {
         this.questionReferences = questionReferences;
         this.deadlineExtensionCount = deadlineExtensionCount;
+        this.questionRoundState = questionRoundState;
     }
 
     public List<CohQuestionReference> getQuestionReferences() {
@@ -19,5 +22,9 @@ public class CohQuestionRound {
 
     public int getDeadlineExtensionCount() {
         return deadlineExtensionCount;
+    }
+
+    public CohState getQuestionRoundState() {
+        return questionRoundState;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -66,7 +66,7 @@ public class DataFixtures {
                 new CohQuestionReference("someQuestionId1", 1, "first question", "first question body",  now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted")),
                 new CohQuestionReference("someQuestionId2", 2, "second question", "second question body",  now().plusDays(10).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))
         );
-        return new CohQuestionRounds(1, singletonList(new CohQuestionRound(cohQuestionReferenceList, 0)));
+        return new CohQuestionRounds(1, singletonList(new CohQuestionRound(cohQuestionReferenceList, 0, someCohState("question_issued"))));
     }
 
     public static CohQuestionRounds someUnpublishedCohQuestionRounds() {
@@ -76,9 +76,9 @@ public class DataFixtures {
     public static CohQuestionRounds someCohQuestionRoundsMultipleRoundsOfQuestions() {
         return new CohQuestionRounds(2, Arrays.asList(
                 new CohQuestionRound(singletonList(
-                        new CohQuestionReference("someQuestionId", 1, "first round question", "first question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))), 0),
+                        new CohQuestionReference("someQuestionId", 1, "first round question", "first question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))), 0, someCohState("question_issued")),
                 new CohQuestionRound(singletonList(
-                        new CohQuestionReference("someOtherQuestionId", 1, "second round question","second question body",  now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))), 0)
+                        new CohQuestionReference("someOtherQuestionId", 1, "second round question","second question body",  now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))), 0, someCohState("question_issued"))
         ));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
@@ -92,7 +92,7 @@ public class QuestionServiceTest {
         CohQuestionRounds cohQuestionRounds = new CohQuestionRounds(1, singletonList(
                 new CohQuestionRound(singletonList(
                         new CohQuestionReference("someQuestionId", 1, "first question", "first question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), null)
-                ), 0)
+                ), 0, someCohState("question_issued"))
         ));
         QuestionSummary questionSummary = createQuestionSummary(cohQuestionRounds, 0, unanswered);
 
@@ -109,7 +109,7 @@ public class QuestionServiceTest {
         CohQuestionRounds cohQuestionRounds = new CohQuestionRounds(1, singletonList(
                 new CohQuestionRound(singletonList(
                         new CohQuestionReference("someQuestionId", 1, "first question", "first question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), null)
-                ), 0)
+                ), 0, someCohState("question_issued"))
         ));
 
         when(cohService.getQuestionRounds(onlineHearingId)).thenReturn(cohQuestionRounds);
@@ -139,7 +139,7 @@ public class QuestionServiceTest {
     public void getsAListOfQuestionsInTheCorrectOrderWhenTheyAreReturnedInTheIncorrectOrder() {
         CohQuestionRounds cohQuestionRounds = new CohQuestionRounds(1, singletonList(new CohQuestionRound(
                 asList(new CohQuestionReference("questionId2", 2, "second question", "second question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted")),
-                        new CohQuestionReference("questionId1", 1, "first question", "first question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))), 0)
+                        new CohQuestionReference("questionId1", 1, "first question", "first question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))), 0, someCohState("question_issued"))
         ));
         CohQuestionReference firstCohQuestionReference = cohQuestionRounds.getCohQuestionRound().get(0)
                 .getQuestionReferences().get(1);
@@ -160,6 +160,17 @@ public class QuestionServiceTest {
                 new QuestionSummary(secondQuestionId, secondQuestionOrdinal, secondQuestionTitle, draft)
                 )
         );
+    }
+
+    @Test
+    public void getsAnEmptyListOfQuestionsIfTheCurrentRoundHasNotBeenIssued() {
+        CohQuestionRounds cohQuestionRounds = new CohQuestionRounds(1, singletonList(new CohQuestionRound(
+                asList(new CohQuestionReference("questionId1", 1, "first question", "first question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), null)), 0, someCohState("question_drafted"))
+        ));
+        when(cohService.getQuestionRounds(onlineHearingId)).thenReturn(cohQuestionRounds);
+        QuestionRound questionRound = underTest.getQuestions(onlineHearingId);
+
+        assertThat(questionRound.getQuestions(), is(emptyList()));
     }
 
     @Test


### PR DESCRIPTION
If you login to a case where the judge has written some questions but
not issued them the questions were viewable in COR.

Fix this by sending the frontend an empty list of questions if the
current question round has not been issued. When you will login to the
frontend you will then see the message

You have no questions from the tribunal