### PR TITLE
Sscs 4922 do not show exceptions

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -87,5 +87,6 @@ module "sscs-core-backend" {
     DOCUMENT_MANAGEMENT_URL = "${local.documentManagementUrl}"
     PDF_API_URL = "${local.pdfService}"
     NOTIFICATIONS_API_URL = "${local.notificationsApiUrl}"
+    ENABLE_DEBUG_ERROR_MESSAGE = "${var.enable_debug_error_message}"
   }
 }

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,2 +1,3 @@
 capacity = "2"
 infrastructure_env = "prod"
+enable_debug_error_message = "false"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -39,3 +39,8 @@ variable "infrastructure_env" {
   default     = "test"
   description = "Infrastructure environment to point to"
 }
+
+variable "enable_debug_error_message" {
+  default     = "true"
+  description = "Enable stack traces on error messages"
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/exception/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/exception/RestResponseEntityExceptionHandler.java
@@ -4,6 +4,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,15 +17,22 @@ import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 @ControllerAdvice
 public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
     private static final Logger LOG = getLogger(RestResponseEntityExceptionHandler.class);
+    private final boolean enableDebugMessage;
+
+    public RestResponseEntityExceptionHandler(@Value("${enable_debug_error_message}")boolean enableDebugMessage) {
+        this.enableDebugMessage = enableDebugMessage;
+    }
 
     @ExceptionHandler(value = { Exception.class })
     protected ResponseEntity<Object> logExceptions(Exception ex, WebRequest request) {
         SscsCorBackendException exc = new SscsCorBackendException(AlertLevel.P3, ex);
         LOG.error("Unhandled exception", exc);
 
+        String body = "An error has occurred" +
+                (enableDebugMessage ? "\n\n" + ExceptionUtils.getStackTrace(ex) : "");
         return handleExceptionInternal(
                 ex,
-                "An error has occurred\n\n" + ExceptionUtils.getStackTrace(ex),
+                body,
                 new HttpHeaders(),
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 request

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -70,3 +70,5 @@ appeal:
     to: ${EMAIL_TO:receiver@hmcts.net}
     subject: ${EMAIL_SUBJECT:Your appeal}
     message: ${EMAIL_MESSAGE:Your appeal has been created \nPlease do not respond to this email}
+
+enable_debug_error_message: ${ENABLE_DEBUG_ERROR_MESSAGE:true}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/exception/RestResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/exception/RestResponseEntityExceptionHandlerTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend.exception;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -11,14 +11,24 @@ import org.springframework.web.context.request.WebRequest;
 
 public class RestResponseEntityExceptionHandlerTest {
 
-    //Just need this to get the code coverage up for the moment
     @Test
-    public void logException() {
+    public void logExceptionWithoutStackTrace() {
         WebRequest request = mock(WebRequest.class);
-        ResponseEntity<Object> foo = new RestResponseEntityExceptionHandler()
+        ResponseEntity<Object> responseEntity = new RestResponseEntityExceptionHandler(false)
                 .logExceptions(new RuntimeException("some exception"), request);
 
-        assertThat(foo, not(nullValue()));
+        assertThat(responseEntity.getBody().toString(), containsString("An error has occurred"));
+        assertThat(responseEntity.getBody().toString(), not(containsString("java.lang.RuntimeException: some exception")));
+
     }
 
+    @Test
+    public void logExceptionWithStackTrace() {
+        WebRequest request = mock(WebRequest.class);
+        ResponseEntity<Object> responseEntity = new RestResponseEntityExceptionHandler(true)
+                .logExceptions(new RuntimeException("some exception"), request);
+
+        assertThat(responseEntity.getBody().toString(), containsString("An error has occurred"));
+        assertThat(responseEntity.getBody().toString(), containsString("java.lang.RuntimeException: some exception"));
+    }
 }


### PR DESCRIPTION
Add a property to turn off the exception stack traces we show in
error response. We want this is dev environments but do not want to
expose them in prod.