### PR TITLE
Allow us to select the case to load if an email address has multiple

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,2 +1,3 @@
 capacity = "2"
 infrastructure_env = "preprod"
+enable_select_by_case_id = "true"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -88,5 +88,6 @@ module "sscs-core-backend" {
     PDF_API_URL = "${local.pdfService}"
     NOTIFICATIONS_API_URL = "${local.notificationsApiUrl}"
     ENABLE_DEBUG_ERROR_MESSAGE = "${var.enable_debug_error_message}"
+    ENABLE_SELECT_BY_CASE_ID = "${var.enable_select_by_case_id}"
   }
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -44,3 +44,7 @@ variable "enable_debug_error_message" {
   default     = "true"
   description = "Enable stack traces on error messages"
 }
+
+variable "enable_select_by_case_id" {
+  default     = "false"
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,3 +72,4 @@ appeal:
     message: ${EMAIL_MESSAGE:Your appeal has been created \nPlease do not respond to this email}
 
 enable_debug_error_message: ${ENABLE_DEBUG_ERROR_MESSAGE:true}
+enable_select_by_case_id: ${ENABLE_SELECT_BY_CASE_ID:false}


### PR DESCRIPTION
appeals in CCD. This is designed for testing so only enabled in AAT.
When the user logs in they enter an email address and add on the case id
in CCD.

i.e. someEmail@example.com+123456

where 123456 is the CCD case id.