### PR TITLE
Return a bad request for CohEvents that are not mapped

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,10 @@ dependencies {
   
   // Removed for now as we have an issue with some of its dependencies
   // compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix-dashboard', version: versions.springHystrix
+  
+  //Remove when our dependencies pull in this version or later
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
+  integrationTestCompile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
   testCompile group: 'junit', name: 'junit', version: versions.junit

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
@@ -105,8 +105,8 @@ public abstract class BaseFunctionTest {
         return httpClientBuilder.build();
     }
 
-    protected void resolveHearing(String hearingId, String caseId) throws IOException {
-        sscsCorBackendRequests.cohHearingResolved(hearingId, caseId);
+    protected void relistHearing(String hearingId, String caseId) throws IOException {
+        sscsCorBackendRequests.cohHearingRelisted(hearingId, caseId);
     }
 
     protected void decisionIssued(String hearingId, String caseId) throws IOException {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CreateHearingPdfTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CreateHearingPdfTest.java
@@ -12,7 +12,7 @@ public class CreateHearingPdfTest extends BaseFunctionTest {
         answerQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());
 
         //now trigger our endpoint
-        resolveHearing(onlineHearing.getHearingId(), onlineHearing.getCaseId());
+        relistHearing(onlineHearing.getHearingId(), onlineHearing.getCaseId());
     }
 
     @Test

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/SscsCorBackendRequests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/SscsCorBackendRequests.java
@@ -128,8 +128,8 @@ public class SscsCorBackendRequests {
         assertThat(getQuestionResponse.getStatusLine().getStatusCode(), is(HttpStatus.NO_CONTENT.value()));
     }
 
-    public void cohHearingResolved(String hearingId, String caseId) throws IOException {
-        cohEvent(hearingId, caseId, "continuous_online_hearing_resolved");
+    public void cohHearingRelisted(String hearingId, String caseId) throws IOException {
+        cohEvent(hearingId, caseId, "continuous_online_hearing_relisted");
     }
 
     public void cohDecisionIssued(String hearingId, String caseId) throws IOException {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/CohEventActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/CohEventActionMapper.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscscorbackend.service.QuestionRoundIssuedService;
+import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingService;
+import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingTribunalsViewService;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
+
+@Service
+public class CohEventActionMapper {
+    private final Map<String, Action> actions;
+
+    @Autowired
+    public CohEventActionMapper(StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService,
+                                NotificationsService notificationsService,
+                                QuestionRoundIssuedService questionRoundIssuedService,
+                                StoreOnlineHearingService storeOnlineHearingService) {
+        this(buildActionsMap(storeOnlineHearingTribunalsViewService, notificationsService, questionRoundIssuedService, storeOnlineHearingService));
+    }
+
+    CohEventActionMapper(HashMap<String, Action> actions) {
+        this.actions = actions;
+    }
+
+    private boolean canHandleEvent(CohEvent event) {
+        return actions.containsKey(event.getEventType());
+    }
+
+    public boolean handle(CohEvent event) {
+        if (canHandleEvent(event)) {
+            String onlineHearingId = event.getOnlineHearingId();
+            Long caseId = Long.valueOf(event.getCaseId());
+
+            actions.get(event.getEventType()).handle(caseId, onlineHearingId, event);
+
+            return true;
+        }
+        return false;
+    }
+
+    private static HashMap<String, Action> buildActionsMap(
+            StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService,
+            NotificationsService notificationsService,
+            QuestionRoundIssuedService questionRoundIssuedService,
+            StoreOnlineHearingService storeOnlineHearingService
+    ) {
+        HashMap<String, Action> actions = new HashMap<>();
+        actions.put("decision_issued", (caseId, onlineHearingId, cohEvent) -> {
+            storeOnlineHearingTribunalsViewService.storePdf(caseId, onlineHearingId);
+            notificationsService.send(cohEvent);
+        });
+        actions.put("question_round_issued", (caseId, onlineHearingId, cohEvent) ->
+            questionRoundIssuedService.handleQuestionRoundIssued(cohEvent)
+        );
+        actions.put("continuous_online_hearing_relisted",  (caseId, onlineHearingId, cohEvent) ->
+            storeOnlineHearingService.storePdf(caseId, onlineHearingId)
+        );
+
+        return actions;
+    }
+
+    @FunctionalInterface
+    interface Action {
+        public void handle(Long caseId, String onlineHearingId, CohEvent cohEvent);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/CohEventActionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/CohEventActionMapperTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someCohEvent;
+
+import java.util.HashMap;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
+
+public class CohEventActionMapperTest {
+
+    private CohEventActionMapper cohEventActionMapper;
+    private CohEventActionMapper.Action action;
+
+    @Before
+    public void setUp() {
+        HashMap<String, CohEventActionMapper.Action> actions = new HashMap<>();
+        action = mock(CohEventActionMapper.Action.class);
+        actions.put("someMappedEvent", action);
+        cohEventActionMapper = new CohEventActionMapper(actions);
+    }
+
+    @Test
+    public void handlesEvent() {
+        CohEvent cohEvent = someCohEvent("1234", "hearingId", "someMappedEvent");
+        boolean handle = cohEventActionMapper.handle(cohEvent);
+
+        verify(action).handle(1234L, "hearingId", cohEvent);
+        assertThat(handle, is(true));
+    }
+
+    @Test
+    public void cannotHandleEventCallsNoActions() {
+        CohEvent cohEvent = someCohEvent("1234", "hearingId", "someUnMappedEvent");
+        boolean handle = cohEventActionMapper.handle(cohEvent);
+
+        verifyZeroInteractions(action);
+        assertThat(handle, is(false));
+    }
+}


### PR DESCRIPTION
If we receive a COH event that we do not have a mapping for return a
bad request response to the client rather than ok.

Split out the mapping for each type of event to its own class and check
this to see if we have a mapping.