### PR TITLE
Fix missing nino on PDFs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.5.RELEASE'
-  id 'org.springframework.boot' version '2.0.3.RELEASE'
+  id 'org.springframework.boot' version '2.1.2.RELEASE'
   id 'org.owasp.dependencycheck' version '3.2.1'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'org.sonarqube' version '2.6.2'
@@ -174,6 +174,8 @@ dependencies {
   //Remove when our dependencies pull in this version or later
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
   integrationTestCompile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
+  integrationTestCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.3.2'
+  functionalTestCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.3.2'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
   testCompile group: 'junit', name: 'junit', version: versions.junit

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/BasePdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/BasePdfService.java
@@ -96,7 +96,7 @@ public abstract class BasePdfService<E> {
         String appellantFirstName = caseDetails.getData().getAppeal().getAppellant().getName().getFirstName();
         String appellantLastName = caseDetails.getData().getAppeal().getAppellant().getName().getLastName();
 
-        String nino = caseDetails.getData().getGeneratedNino();
+        String nino = caseDetails.getData().getAppeal().getAppellant().getIdentity().getNino();
         String caseReference = caseDetails.getData().getCaseReference();
 
         return new PdfAppealDetails(appellantTitle, appellantFirstName, appellantLastName, nino, caseReference);

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,8 @@ spring:
     multipart:
       max-file-size: ${MAX_FILE_SIZE:11MB}
       max-request-size: ${MAX_FILE_SIZE:11MB}
+  main:
+    allow-bean-definition-overriding: true
 
 coh:
   url: ${COH_URL:http://localhost:8081}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/BasePdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/BasePdfServiceTest.java
@@ -121,9 +121,11 @@ public class BasePdfServiceTest {
                                                 .firstName(FIRST_NAME)
                                                 .lastName(LAST_NAME)
                                                 .build())
+                                        .identity(Identity.builder()
+                                                .nino(NINO)
+                                                .build())
                                         .build())
                                 .build())
-                        .generatedNino(NINO)
                         .caseReference(CASE_REF)
                         .build())
                 .build();

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewServiceTest.java
@@ -65,12 +65,18 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
     private SscsCaseData createSscsCaseData() {
         return SscsCaseData.builder()
                 .caseReference(someCaseReference)
-                .generatedNino("someNino")
-                .appeal(Appeal.builder().appellant(Appellant.builder().name(Name.builder()
-                        .title("Mr")
-                        .firstName("Jean")
-                        .lastName("Valjean")
-                        .build()
-                ).build()).build()).build();
+                .appeal(
+                        Appeal.builder().appellant(Appellant.builder()
+                                .name(Name.builder()
+                                        .title("Mr")
+                                    .firstName("Jean")
+                                    .lastName("Valjean")
+                                    .build())
+                                .identity(Identity.builder()
+                                        .nino("someNino")
+                                        .build())
+                            .build())
+                        .build())
+                .build();
     }
 }


### PR DESCRIPTION
We were loading the nino on the appellant identity for the email but for
the PDF were using the generated nino that does not appear to be
populated. Changed the PDF to use the same nino as the email.