### PR TITLE
SSCS-3973 See final decision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ dependencies {
   compileOnly 'org.projectlombok:lombok:1.18.4'
   compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.2.4.RELEASE'
   compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.5.0'
-  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.136'
+  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.137'
 
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.100'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '4.0.2'

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/FinalDecision.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/FinalDecision.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.sscscorbackend.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+
+public class FinalDecision {
+    private final String reason;
+
+    public FinalDecision(String reason) {
+        this.reason = reason;
+    }
+
+    @ApiModelProperty(example = "Some final reason for the decision", required = false)
+    @JsonProperty(value = "reason")
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FinalDecision that = (FinalDecision) o;
+        return Objects.equals(reason, that.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(reason);
+    }
+
+    @Override
+    public String toString() {
+        return "FinalDecision{" +
+                "reason='" + reason + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/OnlineHearing.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/OnlineHearing.java
@@ -12,12 +12,14 @@ public class OnlineHearing {
     private String appellantName;
     private String caseReference;
     private Decision decision;
+    private FinalDecision finalDecision;
 
-    public OnlineHearing(String onlineHearingId, String appellantName, String caseReference, Decision decision) {
+    public OnlineHearing(String onlineHearingId, String appellantName, String caseReference, Decision decision, FinalDecision finalDecision) {
         this.onlineHearingId = onlineHearingId;
         this.appellantName = appellantName;
         this.caseReference = caseReference;
         this.decision = decision;
+        this.finalDecision = finalDecision;
     }
 
     @ApiModelProperty(example = "ID_1", required = true)
@@ -41,5 +43,10 @@ public class OnlineHearing {
     @JsonProperty(value = "decision")
     public Decision getDecision() {
         return decision;
+    }
+
+    @JsonProperty(value = "final_decision")
+    public FinalDecision getFinalDecision() {
+        return finalDecision;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingDateReformatter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingDateReformatter.java
@@ -31,8 +31,8 @@ public class OnlineHearingDateReformatter {
                 onlineHearing.getOnlineHearingId(),
                 onlineHearing.getAppellantName(),
                 onlineHearing.getCaseReference(),
-                newDecision
-        );
+                newDecision,
+                onlineHearing.getFinalDecision());
     }
 
     private String reformatDate(String dateString) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscscorbackend.domain.Decision;
+import uk.gov.hmcts.reform.sscscorbackend.domain.FinalDecision;
 import uk.gov.hmcts.reform.sscscorbackend.domain.OnlineHearing;
 import uk.gov.hmcts.reform.sscscorbackend.domain.TribunalViewResponse;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
@@ -146,8 +147,8 @@ public class OnlineHearingService {
                             onlineHearing.getOnlineHearingId(),
                             nameString,
                             sscsCaseDeails.getData().getCaseReference(),
-                            getDecision(onlineHearing.getOnlineHearingId(), sscsCaseDeails.getId())
-                    );
+                            getDecision(onlineHearing.getOnlineHearingId(), sscsCaseDeails.getId()),
+                            new FinalDecision(sscsCaseDeails.getData().getDecisionNotes()));
                 });
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -109,17 +109,17 @@ public class DataFixtures {
     }
 
     public static OnlineHearing someOnlineHearing() {
-        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", null);
+        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", null, new FinalDecision("final decision"));
     }
 
     public static OnlineHearing someOnlineHearingWithDecision() {
         Decision decision = new Decision("decision_issued", now().format(ISO_LOCAL_DATE_TIME), null, null, "startDate", "endDate", null, "decisionReason", null);
-        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", decision);
+        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", decision, new FinalDecision("final decision"));
     }
 
     public static OnlineHearing someOnlineHearingWithDecisionAndAppellentReply() {
         Decision decision = new Decision("decision_issued", now().format(ISO_LOCAL_DATE_TIME), "decision_accepted", now().format(ISO_LOCAL_DATE_TIME), "startDate", "endDate", null, "decisionReason", null);
-        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", decision);
+        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", decision, new FinalDecision("final decision"));
     }
 
     public static Evidence someEvidence() {

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
@@ -209,6 +209,17 @@ public class OnlineHearingServiceTest {
         assertThat(onlineHearing.isPresent(), is(false));
     }
 
+    @Test
+    public void loadOnlineHearingIncludsFinalDecision() {
+        SscsCaseDetails sscsCaseDetails = createCaseDetails(someCaseId, "caseref", "firstname", "lastname", "online");
+
+        when(cohService.getOnlineHearing(someCaseId)).thenReturn(DataFixtures.someCohOnlineHearings());
+        Optional<OnlineHearing> onlineHearing = underTest.loadOnlineHearingFromCoh(sscsCaseDetails);
+
+        assertThat(onlineHearing.isPresent(), is(true));
+        assertThat(onlineHearing.get().getFinalDecision().getReason(), is(sscsCaseDetails.getData().getDecisionNotes()));
+    }
+
     private SscsCaseDetails createCaseDetails(Long caseId, String expectedCaseReference, String firstName, String lastName) {
         return createCaseDetails(caseId, expectedCaseReference, firstName, lastName, "cor");
     }
@@ -228,8 +239,9 @@ public class OnlineHearingServiceTest {
                                                 .build()
                                         ).build()
                                 ).build()
-                        ).build()
-
+                        )
+                        .decisionNotes("decision notes")
+                        .build()
                 ).build();
     }
 


### PR DESCRIPTION
Once the Judge issues their final decision this will be stored in CCD in
the appeals decision_notes field. Load this value and display it to the
user if they login to the frontend.

- Load the decision notes value from CCD and add it to the online
hearing given to the frontend.