### PR TITLE
Tidy coh event actions

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
@@ -33,6 +33,11 @@ public class AnswerSubmittedEventAction implements CohEventAction {
     }
 
     @Override
+    public String eventCanHandle() {
+        return "answers_submitted";
+    }
+
+    @Override
     public boolean notifyAppellant() {
         return false;
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
@@ -2,16 +2,16 @@ package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreAnswersPdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 
 @Service
 public class AnswerSubmittedEventAction implements CohEventAction {
     private final CorEmailService corEmailService;
-    private final BasePdfService storeAnswersPdfService;
+    private final StorePdfService storeAnswersPdfService;
     private final DwpEmailMessageBuilder dwpEmailMessageBuilder;
 
     public AnswerSubmittedEventAction(CorEmailService corEmailService, StoreAnswersPdfService storeAnswersPdfService, DwpEmailMessageBuilder dwpEmailMessageBuilder) {
@@ -32,7 +32,7 @@ public class AnswerSubmittedEventAction implements CohEventAction {
     }
 
     @Override
-    public BasePdfService getPdfService() {
+    public StorePdfService getPdfService() {
         return storeAnswersPdfService;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
@@ -7,7 +7,6 @@ import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreAnswersPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
 
 @Service
 public class AnswerSubmittedEventAction implements CohEventAction {
@@ -22,7 +21,7 @@ public class AnswerSubmittedEventAction implements CohEventAction {
     }
 
     @Override
-    public void handle(Long caseId, String onlineHearingId, CohEvent cohEvent) {
+    public void handle(Long caseId, String onlineHearingId) {
         StorePdfResult storePdfResult = storeAnswersPdfService.storePdf(caseId, onlineHearingId);
         SscsCaseDetails sscsCaseDetails = storePdfResult.getDocument();
         String caseReference = sscsCaseDetails.getData().getCaseReference();
@@ -31,5 +30,10 @@ public class AnswerSubmittedEventAction implements CohEventAction {
                 "Appellant has provided information (" + caseReference + ")",
                 dwpEmailMessageBuilder.getAnswerMessage(sscsCaseDetails)
         );
+    }
+
+    @Override
+    public boolean notifyAppellant() {
+        return false;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
@@ -21,8 +21,7 @@ public class AnswerSubmittedEventAction implements CohEventAction {
     }
 
     @Override
-    public void handle(Long caseId, String onlineHearingId) {
-        StorePdfResult storePdfResult = storeAnswersPdfService.storePdf(caseId, onlineHearingId);
+    public void handle(Long caseId, String onlineHearingId, StorePdfResult storePdfResult) {
         SscsCaseDetails sscsCaseDetails = storePdfResult.getDocument();
         String caseReference = sscsCaseDetails.getData().getCaseReference();
         corEmailService.sendPdf(
@@ -30,6 +29,11 @@ public class AnswerSubmittedEventAction implements CohEventAction {
                 "Appellant has provided information (" + caseReference + ")",
                 dwpEmailMessageBuilder.getAnswerMessage(sscsCaseDetails)
         );
+    }
+
+    @Override
+    public BasePdfService getPdfService() {
+        return storeAnswersPdfService;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
-import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 
 public interface CohEventAction {
@@ -8,7 +8,7 @@ public interface CohEventAction {
 
     String eventCanHandle();
 
-    BasePdfService getPdfService();
+    StorePdfService getPdfService();
 
     default boolean notifyAppellant() {
         return true;

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
@@ -1,9 +1,14 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
+import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
+
 public interface CohEventAction {
-    void handle(Long caseId, String onlineHearingId);
+    void handle(Long caseId, String onlineHearingId, StorePdfResult storePdfResult);
 
     String eventCanHandle();
+
+    BasePdfService getPdfService();
 
     default boolean notifyAppellant() {
         return true;

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 public interface CohEventAction {
     void handle(Long caseId, String onlineHearingId);
 
+    String eventCanHandle();
+
     default boolean notifyAppellant() {
         return true;
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
@@ -1,8 +1,9 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
-
-@FunctionalInterface
 public interface CohEventAction {
-    void handle(Long caseId, String onlineHearingId, CohEvent cohEvent);
+    void handle(Long caseId, String onlineHearingId);
+
+    default boolean notifyAppellant() {
+        return true;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
@@ -9,38 +8,28 @@ import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.Notifications
 
 @Service
 public class CohEventActionMapper {
-    private final Map<String, CohEventAction> actions;
+    private final List<CohEventAction> actions;
     private final NotificationsService notificationService;
 
     @Autowired
-    public CohEventActionMapper(QuestionRoundIssuedEventAction questionRoundIssuedEventAction,
-                                HearingRelistedAction hearingRelistedAction,
-                                AnswerSubmittedEventAction answerSubmittedEventAction,
-                                DecisionIssuedEventAction decisionIssuedEventAction,
-                                NotificationsService notificationsService) {
-        this(buildActionsMap(questionRoundIssuedEventAction,
-                hearingRelistedAction,
-                answerSubmittedEventAction,
-                decisionIssuedEventAction),
-                notificationsService
-        );
-    }
-
-    CohEventActionMapper(HashMap<String, CohEventAction> actions, NotificationsService notificationService) {
+    public CohEventActionMapper(List<CohEventAction> actions, NotificationsService notificationService) {
         this.actions = actions;
         this.notificationService = notificationService;
     }
 
-    private boolean canHandleEvent(CohEvent event) {
-        return actions.containsKey(event.getEventType());
+    private CohEventAction getActionFor(CohEvent event) {
+        return actions.stream()
+                .filter(action -> action.eventCanHandle().equals(event.getEventType()))
+                .findFirst()
+                .orElse(null);
     }
 
     public boolean handle(CohEvent event) {
-        if (canHandleEvent(event)) {
+        CohEventAction cohEventAction = getActionFor(event);
+        if (cohEventAction != null) {
             String onlineHearingId = event.getOnlineHearingId();
             Long caseId = Long.valueOf(event.getCaseId());
 
-            CohEventAction cohEventAction = actions.get(event.getEventType());
             cohEventAction.handle(caseId, onlineHearingId);
             if (cohEventAction.notifyAppellant()) {
                 notificationService.send(event);
@@ -49,19 +38,4 @@ public class CohEventActionMapper {
         }
         return false;
     }
-
-    private static HashMap<String, CohEventAction> buildActionsMap(
-            QuestionRoundIssuedEventAction questionRoundIssuedEventAction,
-            HearingRelistedAction hearingRelistedAction,
-            AnswerSubmittedEventAction answerSubmittedEventAction,
-            DecisionIssuedEventAction decisionIssuedEventAction) {
-        HashMap<String, CohEventAction> actions = new HashMap<>();
-        actions.put("decision_issued", decisionIssuedEventAction);
-        actions.put("question_round_issued", questionRoundIssuedEventAction);
-        actions.put("continuous_online_hearing_relisted", hearingRelistedAction);
-        actions.put("answers_submitted", answerSubmittedEventAction);
-
-        return actions;
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
@@ -29,8 +30,8 @@ public class CohEventActionMapper {
         if (cohEventAction != null) {
             String onlineHearingId = event.getOnlineHearingId();
             Long caseId = Long.valueOf(event.getCaseId());
-
-            cohEventAction.handle(caseId, onlineHearingId);
+            StorePdfResult storePdfResult = cohEventAction.getPdfService().storePdf(caseId, onlineHearingId);
+            cohEventAction.handle(caseId, onlineHearingId, storePdfResult);
             if (cohEventAction.notifyAppellant()) {
                 notificationService.send(event);
             }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
@@ -5,22 +5,30 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
 @Service
 public class CohEventActionMapper {
     private final Map<String, CohEventAction> actions;
+    private final NotificationsService notificationService;
 
     @Autowired
     public CohEventActionMapper(QuestionRoundIssuedEventAction questionRoundIssuedEventAction,
                                 HearingRelistedAction hearingRelistedAction,
                                 AnswerSubmittedEventAction answerSubmittedEventAction,
-                                DecisionIssuedEventAction decisionIssuedEventAction) {
+                                DecisionIssuedEventAction decisionIssuedEventAction,
+                                NotificationsService notificationsService) {
         this(buildActionsMap(questionRoundIssuedEventAction,
-                hearingRelistedAction, answerSubmittedEventAction, decisionIssuedEventAction));
+                hearingRelistedAction,
+                answerSubmittedEventAction,
+                decisionIssuedEventAction),
+                notificationsService
+        );
     }
 
-    CohEventActionMapper(HashMap<String, CohEventAction> actions) {
+    CohEventActionMapper(HashMap<String, CohEventAction> actions, NotificationsService notificationService) {
         this.actions = actions;
+        this.notificationService = notificationService;
     }
 
     private boolean canHandleEvent(CohEvent event) {
@@ -32,8 +40,11 @@ public class CohEventActionMapper {
             String onlineHearingId = event.getOnlineHearingId();
             Long caseId = Long.valueOf(event.getCaseId());
 
-            actions.get(event.getEventType()).handle(caseId, onlineHearingId, event);
-
+            CohEventAction cohEventAction = actions.get(event.getEventType());
+            cohEventAction.handle(caseId, onlineHearingId);
+            if (cohEventAction.notifyAppellant()) {
+                notificationService.send(event);
+            }
             return true;
         }
         return false;

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventAction.java
@@ -28,4 +28,9 @@ public class DecisionIssuedEventAction implements CohEventAction {
                 dwpEmailMessageBuilder.getDecisionIssuedMessage(storePdfResult.getDocument())
         );
     }
+
+    @Override
+    public String eventCanHandle() {
+        return "decision_issued";
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventAction.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingTribunalsViewService;
+import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 
 @Service
@@ -35,7 +35,7 @@ public class DecisionIssuedEventAction implements CohEventAction {
     }
 
     @Override
-    public BasePdfService getPdfService() {
+    public StorePdfService getPdfService() {
         return storeOnlineHearingTribunalsViewService;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventAction.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingTribunalsViewService;
@@ -19,8 +20,7 @@ public class DecisionIssuedEventAction implements CohEventAction {
     }
 
     @Override
-    public void handle(Long caseId, String onlineHearingId) {
-        StorePdfResult storePdfResult = storeOnlineHearingTribunalsViewService.storePdf(caseId, onlineHearingId);
+    public void handle(Long caseId, String onlineHearingId, StorePdfResult storePdfResult) {
         String caseReference = storePdfResult.getDocument().getData().getCaseReference();
         emailService.sendPdf(
                 storePdfResult,
@@ -32,5 +32,10 @@ public class DecisionIssuedEventAction implements CohEventAction {
     @Override
     public String eventCanHandle() {
         return "decision_issued";
+    }
+
+    @Override
+    public BasePdfService getPdfService() {
+        return storeOnlineHearingTribunalsViewService;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventAction.java
@@ -5,25 +5,21 @@ import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingTribunalsViewService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
 @Service
 public class DecisionIssuedEventAction implements CohEventAction {
     private final StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService;
-    private final NotificationsService notificationsService;
     private final CorEmailService emailService;
     private final DwpEmailMessageBuilder dwpEmailMessageBuilder;
 
-    public DecisionIssuedEventAction(StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService, NotificationsService notificationsService, CorEmailService emailService, DwpEmailMessageBuilder dwpEmailMessageBuilder) {
+    public DecisionIssuedEventAction(StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService, CorEmailService emailService, DwpEmailMessageBuilder dwpEmailMessageBuilder) {
         this.storeOnlineHearingTribunalsViewService = storeOnlineHearingTribunalsViewService;
-        this.notificationsService = notificationsService;
         this.emailService = emailService;
         this.dwpEmailMessageBuilder = dwpEmailMessageBuilder;
     }
 
     @Override
-    public void handle(Long caseId, String onlineHearingId, CohEvent cohEvent) {
+    public void handle(Long caseId, String onlineHearingId) {
         StorePdfResult storePdfResult = storeOnlineHearingTribunalsViewService.storePdf(caseId, onlineHearingId);
         String caseReference = storePdfResult.getDocument().getData().getCaseReference();
         emailService.sendPdf(
@@ -31,6 +27,5 @@ public class DecisionIssuedEventAction implements CohEventAction {
                 "Preliminary view offered (" + caseReference + ")",
                 dwpEmailMessageBuilder.getDecisionIssuedMessage(storePdfResult.getDocument())
         );
-        notificationsService.send(cohEvent);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedAction.java
@@ -12,13 +12,10 @@ import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
 @Service
 public class HearingRelistedAction implements CohEventAction {
     private final StoreOnlineHearingService storeOnlineHearingService;
-    private final NotificationsService notificationsService;
     private final CorCcdService corCcdService;
     private final IdamService idamService;
     private final CorEmailService corEmailService;
@@ -26,12 +23,10 @@ public class HearingRelistedAction implements CohEventAction {
 
     @Autowired
     public HearingRelistedAction(StoreOnlineHearingService storeOnlineHearingService,
-                                 NotificationsService notificationsService,
                                  CorCcdService corCcdService, IdamService idamService,
                                  CorEmailService corEmailService,
                                  DwpEmailMessageBuilder dwpEmailMessageBuilder) {
         this.storeOnlineHearingService = storeOnlineHearingService;
-        this.notificationsService = notificationsService;
         this.corCcdService = corCcdService;
         this.idamService = idamService;
         this.corEmailService = corEmailService;
@@ -39,9 +34,8 @@ public class HearingRelistedAction implements CohEventAction {
     }
 
     @Override
-    public void handle(Long caseId, String onlineHearingId, CohEvent cohEvent) {
+    public void handle(Long caseId, String onlineHearingId) {
         StorePdfResult storePdfResult = storeOnlineHearingService.storePdf(caseId, onlineHearingId);
-        notificationsService.send(cohEvent);
         updateCcdCaseToOralHearing(caseId, storePdfResult);
         String relistedMessage = dwpEmailMessageBuilder.getRelistedMessage(storePdfResult.getDocument());
         corEmailService.sendEmail("COR: Hearing required", relistedMessage);

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedAction.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingService;
@@ -34,8 +35,7 @@ public class HearingRelistedAction implements CohEventAction {
     }
 
     @Override
-    public void handle(Long caseId, String onlineHearingId) {
-        StorePdfResult storePdfResult = storeOnlineHearingService.storePdf(caseId, onlineHearingId);
+    public void handle(Long caseId, String onlineHearingId, StorePdfResult storePdfResult) {
         updateCcdCaseToOralHearing(caseId, storePdfResult);
         String relistedMessage = dwpEmailMessageBuilder.getRelistedMessage(storePdfResult.getDocument());
         corEmailService.sendEmail("COR: Hearing required", relistedMessage);
@@ -64,5 +64,10 @@ public class HearingRelistedAction implements CohEventAction {
     @Override
     public String eventCanHandle() {
         return "continuous_online_hearing_relisted";
+    }
+
+    @Override
+    public BasePdfService getPdfService() {
+        return storeOnlineHearingService;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedAction.java
@@ -7,10 +7,10 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
-import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingService;
+import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
 
@@ -67,7 +67,7 @@ public class HearingRelistedAction implements CohEventAction {
     }
 
     @Override
-    public BasePdfService getPdfService() {
+    public StorePdfService getPdfService() {
         return storeOnlineHearingService;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedAction.java
@@ -60,4 +60,9 @@ public class HearingRelistedAction implements CohEventAction {
                 .appeal(data.getAppeal().toBuilder().hearingType("oral").build())
                 .build();
     }
+
+    @Override
+    public String eventCanHandle() {
+        return "continuous_online_hearing_relisted";
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventAction.java
@@ -2,9 +2,9 @@ package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
+import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreQuestionsPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 
@@ -28,7 +28,7 @@ public class QuestionRoundIssuedEventAction implements CohEventAction {
         sendDwpEmail(storePdfResult, sscsCaseDetails);
     }
 
-    public BasePdfService getPdfService() {
+    public StorePdfService getPdfService() {
         return storeQuestionsPdfService;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventAction.java
@@ -6,29 +6,23 @@ import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreQuestionsPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
 @Service
 public class QuestionRoundIssuedEventAction implements CohEventAction {
-    private final NotificationsService notificationsService;
     private final StoreQuestionsPdfService storeQuestionsPdfService;
     private final CorEmailService corEmailService;
     private final DwpEmailMessageBuilder dwpEmailMessageBuilder;
 
-    public QuestionRoundIssuedEventAction(NotificationsService notificationsService,
-                                          StoreQuestionsPdfService storeQuestionsPdfService,
+    public QuestionRoundIssuedEventAction(StoreQuestionsPdfService storeQuestionsPdfService,
                                           CorEmailService corEmailService,
                                           DwpEmailMessageBuilder dwpEmailMessageBuilder) {
-        this.notificationsService = notificationsService;
         this.storeQuestionsPdfService = storeQuestionsPdfService;
         this.corEmailService = corEmailService;
         this.dwpEmailMessageBuilder = dwpEmailMessageBuilder;
     }
 
     @Override
-    public void handle(Long caseId, String onlineHearingId, CohEvent cohEvent) {
-        notificationsService.send(cohEvent);
+    public void handle(Long caseId, String onlineHearingId) {
         StorePdfResult storePdfResult = storeQuestionsPdfService.storePdf(
                 caseId,
                 onlineHearingId

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventAction.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreQuestionsPdfService;
@@ -22,18 +23,29 @@ public class QuestionRoundIssuedEventAction implements CohEventAction {
     }
 
     @Override
-    public void handle(Long caseId, String onlineHearingId) {
-        StorePdfResult storePdfResult = storeQuestionsPdfService.storePdf(
-                caseId,
-                onlineHearingId
-        );
+    public void handle(Long caseId, String onlineHearingId, StorePdfResult storePdfResult) {
         SscsCaseDetails sscsCaseDetails = storePdfResult.getDocument();
-        String caseReference = sscsCaseDetails.getData().getCaseReference();
+        sendDwpEmail(storePdfResult, sscsCaseDetails);
+    }
+
+    public BasePdfService getPdfService() {
+        return storeQuestionsPdfService;
+    }
+
+    private void sendDwpEmail(StorePdfResult storePdfResult, SscsCaseDetails sscsCaseDetails) {
         corEmailService.sendPdf(
                 storePdfResult,
-                "Questions issued to the appellant (" + caseReference + ")",
-                dwpEmailMessageBuilder.getQuestionMessage(sscsCaseDetails)
+                getDwpEmailSubject(sscsCaseDetails),
+                getDwpEmailMessage(sscsCaseDetails)
         );
+    }
+
+    private String getDwpEmailMessage(SscsCaseDetails sscsCaseDetails) {
+        return dwpEmailMessageBuilder.getQuestionMessage(sscsCaseDetails);
+    }
+
+    private String getDwpEmailSubject(SscsCaseDetails sscsCaseDetails) {
+        return "Questions issued to the appellant (" + sscsCaseDetails.getData().getCaseReference() + ")";
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventAction.java
@@ -35,4 +35,9 @@ public class QuestionRoundIssuedEventAction implements CohEventAction {
                 dwpEmailMessageBuilder.getQuestionMessage(sscsCaseDetails)
         );
     }
+
+    @Override
+    public String eventCanHandle() {
+        return "question_round_issued";
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AbstractQuestionPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AbstractQuestionPdfService.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
-public abstract class AbstractQuestionPdfService extends BasePdfService<PdfQuestionsSummary> {
+public abstract class AbstractQuestionPdfService extends StorePdfService<PdfQuestionsSummary> {
     private final QuestionService questionService;
 
     @SuppressWarnings("squid:S00107")

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingService.java
@@ -17,7 +17,7 @@ import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 @Slf4j
 @Service
-public class StoreOnlineHearingService extends BasePdfService<PdfSummary> {
+public class StoreOnlineHearingService extends StorePdfService<PdfSummary> {
     private final CohService cohService;
     private final PdfSummaryBuilder pdfSummaryBuilder;
 

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewService.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 @Slf4j
 @Service
-public class StoreOnlineHearingTribunalsViewService extends BasePdfService<OnlineHearing> {
+public class StoreOnlineHearingTribunalsViewService extends StorePdfService<OnlineHearing> {
 
     public static final String TRIBUNALS_VIEW_PDF_PREFIX = "Tribunals view - ";
     private final OnlineHearingService onlineHearingService;

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfService.java
@@ -19,7 +19,7 @@ import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 @Slf4j
-public abstract class BasePdfService<E> {
+public abstract class StorePdfService<E> {
     private final PdfService pdfService;
     private final String pdfTemplatePath;
     private final SscsPdfService sscsPdfService;
@@ -27,12 +27,12 @@ public abstract class BasePdfService<E> {
     private final IdamService idamService;
     private final EvidenceManagementService evidenceManagementService;
 
-    BasePdfService(PdfService pdfService,
-                   String pdfTemplatePath,
-                   SscsPdfService sscsPdfService,
-                   CcdService ccdService,
-                   IdamService idamService,
-                   EvidenceManagementService evidenceManagementService) {
+    StorePdfService(PdfService pdfService,
+                    String pdfTemplatePath,
+                    SscsPdfService sscsPdfService,
+                    CcdService ccdService,
+                    IdamService idamService,
+                    EvidenceManagementService evidenceManagementService) {
         this.pdfService = pdfService;
         this.pdfTemplatePath = pdfTemplatePath;
         this.sscsPdfService = sscsPdfService;

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventActionTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.*;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreAnswersPdfService;
@@ -32,7 +31,7 @@ public class AnswerSubmittedEventActionTest {
         when(storeAnswersPdfService.storePdf(caseId, onlineHearingId)).thenReturn(storePdfResult);
         when(dwpEmailMessageBuilder.getAnswerMessage(caseDetails)).thenReturn("some message");
 
-        answerSubmittedEventAction.handle(caseId, onlineHearingId, DataFixtures.someCohEvent(caseId + "", onlineHearingId, "some_event"));
+        answerSubmittedEventAction.handle(caseId, onlineHearingId);
 
         verify(corEmailService).sendPdf(storePdfResult, "Appellant has provided information (" + someCaseReference + ")", "some message");
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventActionTest.java
@@ -28,12 +28,10 @@ public class AnswerSubmittedEventActionTest {
         String onlineHearingId = "onlineHearingId";
         String pdfName = "pdf_name.pdf";
         StorePdfResult storePdfResult = new StorePdfResult(new Pdf(new byte[]{2, 5, 6, 0, 1}, pdfName), caseDetails);
-        when(storeAnswersPdfService.storePdf(caseId, onlineHearingId)).thenReturn(storePdfResult);
         when(dwpEmailMessageBuilder.getAnswerMessage(caseDetails)).thenReturn("some message");
 
-        answerSubmittedEventAction.handle(caseId, onlineHearingId);
+        answerSubmittedEventAction.handle(caseId, onlineHearingId, storePdfResult);
 
         verify(corEmailService).sendPdf(storePdfResult, "Appellant has provided information (" + someCaseReference + ")", "some message");
     }
-
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventCohEventActionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventCohEventActionMapperTest.java
@@ -9,7 +9,7 @@ import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someCohEvent;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.hmcts.reform.sscscorbackend.service.BasePdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
@@ -23,7 +23,7 @@ public class CohEventCohEventActionMapperTest {
     private long caseIdLong;
     private String hearingId;
     private StorePdfResult storePdfResult;
-    private BasePdfService basePdfService;
+    private StorePdfService storePdfService;
 
     @Before
     public void setUp() {
@@ -32,10 +32,10 @@ public class CohEventCohEventActionMapperTest {
         hearingId = "hearingId";
         action = mock(CohEventAction.class);
         when(action.eventCanHandle()).thenReturn("someMappedEvent");
-        basePdfService = mock(BasePdfService.class);
+        storePdfService = mock(StorePdfService.class);
         storePdfResult = mock(StorePdfResult.class);
-        when(basePdfService.storePdf(caseIdLong, hearingId)).thenReturn(storePdfResult);
-        when(action.getPdfService()).thenReturn(basePdfService);
+        when(storePdfService.storePdf(caseIdLong, hearingId)).thenReturn(storePdfResult);
+        when(action.getPdfService()).thenReturn(storePdfService);
         List<CohEventAction> actions = singletonList(action);
         notificationService = mock(NotificationsService.class);
         cohEventActionMapper = new CohEventActionMapper(actions, notificationService);
@@ -48,7 +48,7 @@ public class CohEventCohEventActionMapperTest {
         boolean handle = cohEventActionMapper.handle(cohEvent);
 
         verify(action).handle(caseIdLong, hearingId, storePdfResult);
-        verify(basePdfService).storePdf(caseIdLong, hearingId);
+        verify(storePdfService).storePdf(caseIdLong, hearingId);
         verify(notificationService).send(cohEvent);
         assertThat(handle, is(true));
     }
@@ -60,7 +60,7 @@ public class CohEventCohEventActionMapperTest {
         boolean handle = cohEventActionMapper.handle(cohEvent);
 
         verify(action).handle(caseIdLong, hearingId, storePdfResult);
-        verify(basePdfService).storePdf(caseIdLong, hearingId);
+        verify(storePdfService).storePdf(caseIdLong, hearingId);
         verifyZeroInteractions(notificationService);
         assertThat(handle, is(true));
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventCohEventActionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventCohEventActionMapperTest.java
@@ -1,11 +1,12 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someCohEvent;
 
-import java.util.HashMap;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
@@ -19,9 +20,9 @@ public class CohEventCohEventActionMapperTest {
 
     @Before
     public void setUp() {
-        HashMap<String, CohEventAction> actions = new HashMap<>();
         action = mock(CohEventAction.class);
-        actions.put("someMappedEvent", action);
+        when(action.eventCanHandle()).thenReturn("someMappedEvent");
+        List<CohEventAction> actions = singletonList(action);
         notificationService = mock(NotificationsService.class);
         cohEventActionMapper = new CohEventActionMapper(actions, notificationService);
     }
@@ -53,7 +54,8 @@ public class CohEventCohEventActionMapperTest {
         CohEvent cohEvent = someCohEvent("1234", "hearingId", "someUnMappedEvent");
         boolean handle = cohEventActionMapper.handle(cohEvent);
 
-        verifyZeroInteractions(action);
+        verify(action, never()).handle(any(Long.class), any(String.class));
+        verifyZeroInteractions(notificationService);
         assertThat(handle, is(false));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventActionTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
 import static org.mockito.Mockito.*;
-import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someCohEvent;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someStorePdfResult;
 
 import org.junit.Before;
@@ -10,27 +9,22 @@ import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingTribunalsViewService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
 public class DecisionIssuedEventActionTest {
 
     private StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService;
-    private NotificationsService notificationsService;
     private CorEmailService corEmailService;
     private DwpEmailMessageBuilder dwpEmailMessageBuilder;
     private DecisionIssuedEventAction decisionIssuedEventAction;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         storeOnlineHearingTribunalsViewService = mock(StoreOnlineHearingTribunalsViewService.class);
-        notificationsService = mock(NotificationsService.class);
         corEmailService = mock(CorEmailService.class);
         dwpEmailMessageBuilder = mock(DwpEmailMessageBuilder.class);
 
         decisionIssuedEventAction = new DecisionIssuedEventAction(
                 storeOnlineHearingTribunalsViewService,
-                notificationsService,
                 corEmailService,
                 dwpEmailMessageBuilder
         );
@@ -44,12 +38,10 @@ public class DecisionIssuedEventActionTest {
 
         long caseId = 123L;
         String onlineHearingId = "onlineHearingId";
-        CohEvent decisionIssued = someCohEvent(caseId + "", onlineHearingId, "decision_issued");
         when(storeOnlineHearingTribunalsViewService.storePdf(caseId, onlineHearingId)).thenReturn(storePdfResult);
 
-        decisionIssuedEventAction.handle(caseId, onlineHearingId, decisionIssued);
+        decisionIssuedEventAction.handle(caseId, onlineHearingId);
 
-        verify(notificationsService).send(decisionIssued);
         String subject = "Preliminary view offered (" + storePdfResult.getDocument().getData().getCaseReference() + ")";
         verify(corEmailService).sendPdf(storePdfResult, subject, message);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventActionTest.java
@@ -12,14 +12,13 @@ import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 
 public class DecisionIssuedEventActionTest {
 
-    private StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService;
     private CorEmailService corEmailService;
     private DwpEmailMessageBuilder dwpEmailMessageBuilder;
     private DecisionIssuedEventAction decisionIssuedEventAction;
 
     @Before
     public void setUp() {
-        storeOnlineHearingTribunalsViewService = mock(StoreOnlineHearingTribunalsViewService.class);
+        StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService = mock(StoreOnlineHearingTribunalsViewService.class);
         corEmailService = mock(CorEmailService.class);
         dwpEmailMessageBuilder = mock(DwpEmailMessageBuilder.class);
 
@@ -38,9 +37,8 @@ public class DecisionIssuedEventActionTest {
 
         long caseId = 123L;
         String onlineHearingId = "onlineHearingId";
-        when(storeOnlineHearingTribunalsViewService.storePdf(caseId, onlineHearingId)).thenReturn(storePdfResult);
 
-        decisionIssuedEventAction.handle(caseId, onlineHearingId);
+        decisionIssuedEventAction.handle(caseId, onlineHearingId, storePdfResult);
 
         String subject = "Preliminary view offered (" + storePdfResult.getDocument().getData().getCaseReference() + ")";
         verify(corEmailService).sendPdf(storePdfResult, subject, message);

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedActionTest.java
@@ -21,7 +21,6 @@ import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
 
 public class HearingRelistedActionTest {
 
-    private StoreOnlineHearingService storeOnlineHearingService;
     private CorCcdService corCcdService;
     private IdamTokens idamTokens;
     private Long caseId;
@@ -32,7 +31,6 @@ public class HearingRelistedActionTest {
 
     @Before
     public void setUp() {
-        storeOnlineHearingService = mock(StoreOnlineHearingService.class);
         corCcdService = mock(CorCcdService.class);
         IdamService idamService = mock(IdamService.class);
         idamTokens = mock(IdamTokens.class);
@@ -42,7 +40,7 @@ public class HearingRelistedActionTest {
         corEmailService = mock(CorEmailService.class);
 
         dwpEmailMessageBuilder = mock(DwpEmailMessageBuilder.class);
-        underTest = new HearingRelistedAction(storeOnlineHearingService, corCcdService, idamService, corEmailService, dwpEmailMessageBuilder);
+        underTest = new HearingRelistedAction(mock(StoreOnlineHearingService.class), corCcdService, idamService, corEmailService, dwpEmailMessageBuilder);
     }
 
     @Test
@@ -54,13 +52,11 @@ public class HearingRelistedActionTest {
                                 .build())
                         .build())
                 .build();
-        when(storeOnlineHearingService.storePdf(caseId, onlineHearingId))
-                .thenReturn(new StorePdfResult(mock(Pdf.class), sscsCaseDetails));
+        StorePdfResult storePdfResult = new StorePdfResult(mock(Pdf.class), sscsCaseDetails);
         when(dwpEmailMessageBuilder.getRelistedMessage(sscsCaseDetails)).thenReturn("message body");
 
-        underTest.handle(caseId, onlineHearingId);
+        underTest.handle(caseId, onlineHearingId, storePdfResult);
 
-        verify(storeOnlineHearingService).storePdf(caseId, onlineHearingId);
         ArgumentMatcher<SscsCaseData> hasOralHearing = data -> data.getAppeal().getHearingType().equals("oral");
         verify(corCcdService).updateCase(
                 argThat(hasOralHearing),

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/HearingRelistedActionTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
-import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someCohEvent;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -19,19 +18,14 @@ import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.Pdf;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
 public class HearingRelistedActionTest {
 
     private StoreOnlineHearingService storeOnlineHearingService;
-    private NotificationsService notificationsService;
     private CorCcdService corCcdService;
-    private IdamService idamService;
     private IdamTokens idamTokens;
     private Long caseId;
     private String onlineHearingId;
-    private CohEvent cohEvent;
     private HearingRelistedAction underTest;
     private CorEmailService corEmailService;
     private DwpEmailMessageBuilder dwpEmailMessageBuilder;
@@ -39,18 +33,16 @@ public class HearingRelistedActionTest {
     @Before
     public void setUp() {
         storeOnlineHearingService = mock(StoreOnlineHearingService.class);
-        notificationsService = mock(NotificationsService.class);
         corCcdService = mock(CorCcdService.class);
-        idamService = mock(IdamService.class);
+        IdamService idamService = mock(IdamService.class);
         idamTokens = mock(IdamTokens.class);
         when(idamService.getIdamTokens()).thenReturn(idamTokens);
         caseId = 12345L;
         onlineHearingId = "onlineHearingId";
-        cohEvent = someCohEvent(caseId.toString(), onlineHearingId, "continuous_online_hearing_relisted");
         corEmailService = mock(CorEmailService.class);
 
         dwpEmailMessageBuilder = mock(DwpEmailMessageBuilder.class);
-        underTest = new HearingRelistedAction(storeOnlineHearingService, notificationsService, corCcdService, idamService, corEmailService, dwpEmailMessageBuilder);
+        underTest = new HearingRelistedAction(storeOnlineHearingService, corCcdService, idamService, corEmailService, dwpEmailMessageBuilder);
     }
 
     @Test
@@ -66,10 +58,9 @@ public class HearingRelistedActionTest {
                 .thenReturn(new StorePdfResult(mock(Pdf.class), sscsCaseDetails));
         when(dwpEmailMessageBuilder.getRelistedMessage(sscsCaseDetails)).thenReturn("message body");
 
-        underTest.handle(caseId, onlineHearingId, cohEvent);
+        underTest.handle(caseId, onlineHearingId);
 
         verify(storeOnlineHearingService).storePdf(caseId, onlineHearingId);
-        verify(notificationsService).send(cohEvent);
         ArgumentMatcher<SscsCaseData> hasOralHearing = data -> data.getAppeal().getHearingType().equals("oral");
         verify(corCcdService).updateCase(
                 argThat(hasOralHearing),

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventActionTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
 import static org.mockito.Mockito.*;
-import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someCohEvent;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -11,12 +10,8 @@ import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreQuestionsPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
 public class QuestionRoundIssuedEventActionTest {
-
-    private NotificationsService notificationsService;
     private StoreQuestionsPdfService storeQuestionsPdfService;
     private CorEmailService corEmailService;
     private QuestionRoundIssuedEventAction questionRoundIssuedEventAction;
@@ -26,12 +21,11 @@ public class QuestionRoundIssuedEventActionTest {
 
     @Before
     public void setUp() {
-        notificationsService = mock(NotificationsService.class);
         storeQuestionsPdfService = mock(StoreQuestionsPdfService.class);
         corEmailService = mock(CorEmailService.class);
         dwpEmailMessageBuilder = mock(DwpEmailMessageBuilder.class);
         questionRoundIssuedEventAction = new QuestionRoundIssuedEventAction(
-                notificationsService, storeQuestionsPdfService, corEmailService,
+                storeQuestionsPdfService, corEmailService,
                 dwpEmailMessageBuilder);
         caseId = 123456L;
         hearingId = "someHearingId";
@@ -50,11 +44,9 @@ public class QuestionRoundIssuedEventActionTest {
         when(storeQuestionsPdfService.storePdf(caseId, hearingId)).thenReturn(storePdfResult);
         String message = "message";
         when(dwpEmailMessageBuilder.getQuestionMessage(sscsCaseDetails)).thenReturn(message);
-        CohEvent cohEvent = someCohEvent(caseId.toString(), hearingId, "some_event");
 
-        questionRoundIssuedEventAction.handle(caseId, hearingId, cohEvent);
+        questionRoundIssuedEventAction.handle(caseId, hearingId);
 
-        verify(notificationsService).send(cohEvent);
         verify(corEmailService).sendPdf(storePdfResult, "Questions issued to the appellant (" + caseReference + ")", message);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventActionTest.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.sscscorbackend.service.StoreQuestionsPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 
 public class QuestionRoundIssuedEventActionTest {
-    private StoreQuestionsPdfService storeQuestionsPdfService;
     private CorEmailService corEmailService;
     private QuestionRoundIssuedEventAction questionRoundIssuedEventAction;
     private Long caseId;
@@ -21,7 +20,7 @@ public class QuestionRoundIssuedEventActionTest {
 
     @Before
     public void setUp() {
-        storeQuestionsPdfService = mock(StoreQuestionsPdfService.class);
+        StoreQuestionsPdfService storeQuestionsPdfService = mock(StoreQuestionsPdfService.class);
         corEmailService = mock(CorEmailService.class);
         dwpEmailMessageBuilder = mock(DwpEmailMessageBuilder.class);
         questionRoundIssuedEventAction = new QuestionRoundIssuedEventAction(
@@ -41,11 +40,10 @@ public class QuestionRoundIssuedEventActionTest {
                         .build())
                 .build();
         when(storePdfResult.getDocument()).thenReturn(sscsCaseDetails);
-        when(storeQuestionsPdfService.storePdf(caseId, hearingId)).thenReturn(storePdfResult);
         String message = "message";
         when(dwpEmailMessageBuilder.getQuestionMessage(sscsCaseDetails)).thenReturn(message);
 
-        questionRoundIssuedEventAction.handle(caseId, hearingId);
+        questionRoundIssuedEventAction.handle(caseId, hearingId, storePdfResult);
 
         verify(corEmailService).sendPdf(storePdfResult, "Questions issued to the appellant (" + caseReference + ")", message);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfServiceTest.java
@@ -19,7 +19,7 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
-public class BasePdfServiceTest {
+public class StorePdfServiceTest {
     private static final String TITLE = "title";
     private static final String FIRST_NAME = "firstName";
     private static final String LAST_NAME = "lastName";
@@ -33,7 +33,7 @@ public class BasePdfServiceTest {
     private long caseId;
     private Object pdfContent;
     private String fileNamePrefix;
-    private BasePdfService basePdfService;
+    private StorePdfService storePdfService;
     private IdamTokens idamTokens;
     private String someOnlineHearingId;
     private EvidenceManagementService evidenceManagementService;
@@ -50,7 +50,7 @@ public class BasePdfServiceTest {
         pdfContent = new Object();
         fileNamePrefix = "test name";
         evidenceManagementService = mock(EvidenceManagementService.class);
-        basePdfService = new BasePdfService(pdfService, "sometemplate", sscsPdfService, ccdService, idamService, evidenceManagementService) {
+        storePdfService = new StorePdfService(pdfService, "sometemplate", sscsPdfService, ccdService, idamService, evidenceManagementService) {
 
             @Override
             protected String documentNamePrefix(SscsCaseDetails caseDetails, String onlineHearingId) {
@@ -72,7 +72,7 @@ public class BasePdfServiceTest {
         byte[] expectedPdfBytes = {2, 4, 6, 0, 1};
         when(pdfService.createPdf(pdfContent, "sometemplate")).thenReturn(expectedPdfBytes);
 
-        StorePdfResult storePdfResult = basePdfService.storePdf(caseId, someOnlineHearingId);
+        StorePdfResult storePdfResult = storePdfService.storePdf(caseId, someOnlineHearingId);
 
         verify(sscsPdfService).mergeDocIntoCcd(fileNamePrefix + CASE_REF + ".pdf", expectedPdfBytes, caseId, caseDetails.getData(), idamTokens);
         assertThat(storePdfResult.getPdf().getContent(), is(expectedPdfBytes));
@@ -103,7 +103,7 @@ public class BasePdfServiceTest {
         byte[] expectedPdfBytes = {2, 4, 6, 0, 1};
         when(evidenceManagementService.download(new URI(documentUrl), "sscs")).thenReturn(expectedPdfBytes);
 
-        StorePdfResult storePdfResult = basePdfService.storePdf(caseId, someOnlineHearingId);
+        StorePdfResult storePdfResult = storePdfService.storePdf(caseId, someOnlineHearingId);
 
         verifyZeroInteractions(sscsPdfService);
         assertThat(storePdfResult.getPdf().getContent(), is(expectedPdfBytes));


### PR DESCRIPTION
- Made QuestionRoundIssuedService into a CohEventAction to match all the
other ways we handle CohEvents.
- Moved sending coh events to the notify service from each action and made
this part of the mapper class which checks with the action if
notifications need to be sent.
- Added the events actions handle to the action. Gets rid of the map we
need to build up in CohEventActionMapper. This means now if you have an
implementation of CohEventAction.java and it is created in the Spring
context it will get picked up by the mapper we no longer need to wire
it by hand.
- Moved create and store PDF out of each action to the mapper as it is
always the first thing we do.
- Renamed BasePdfService to StorePdfService