### PR TITLE
Handle COH event in a separte thread

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
@@ -91,7 +91,7 @@ public class CcdStub extends BaseStub {
     }
 
     public void verifyUpdateCaseWithPdf(Long caseId, String caseReference, String pdfName) throws JsonProcessingException {
-        wireMock.verify(postRequestedFor(urlEqualTo("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/events?ignore-warning=true"))
+        verifyAsync(postRequestedFor(urlEqualTo("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/events?ignore-warning=true"))
                 .withRequestBody(matchingJsonPath("$.event.summary", equalTo("SSCS - appeal updated event")))
                 .withRequestBody(matchingJsonPath("$.data.caseReference", equalTo(caseReference)))
                 .withRequestBody(matchingJsonPath("$.data.sscsDocument[0].value.documentFileName", equalTo(pdfName)))
@@ -99,7 +99,7 @@ public class CcdStub extends BaseStub {
     }
 
     public void verifyUpdateCaseToOralHearing(Long caseId, String caseReference) throws JsonProcessingException {
-        wireMock.verify(postRequestedFor(urlEqualTo("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/events?ignore-warning=true"))
+        verifyAsync(postRequestedFor(urlEqualTo("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/events?ignore-warning=true"))
                 .withRequestBody(matchingJsonPath("$.event.summary", equalTo("SSCS - appeal updated event")))
                 .withRequestBody(matchingJsonPath("$.data.caseReference", equalTo(caseReference)))
                 .withRequestBody(matchingJsonPath("$.data.appeal.hearingType", equalTo("oral")))

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/DocumentStoreStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/DocumentStoreStub.java
@@ -32,7 +32,7 @@ public class DocumentStoreStub extends BaseStub {
     }
 
     public void verifyUploadFile(byte[] pdfBytes) {
-        wireMock.verify(postRequestedFor(urlEqualTo("/documents"))
+        verifyAsync(postRequestedFor(urlEqualTo("/documents"))
             .withRequestBody(containing(Arrays.toString(pdfBytes)))
         );
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/MailStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/MailStub.java
@@ -28,7 +28,7 @@ public class MailStub {
 
     public void waitForEmailThatMatches(Predicate<SmtpMessage> matches, String expected) {
         List<SmtpMessage> receivedEmails = emptyList();
-        for (int counter = 0; counter < 10; counter++) {
+        for (int counter = 0; counter < 50; counter++) {
             receivedEmails = smtpServer.getReceivedEmails();
             if (receivedEmails.stream().anyMatch(matches)) {
                 return;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/MailStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/MailStub.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.stubs;
 
-import static java.util.stream.Collectors.toList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -10,8 +10,9 @@ import com.dumbster.smtp.SmtpMessage;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.junit.Assert;
 
 public class MailStub {
 
@@ -25,76 +26,47 @@ public class MailStub {
         smtpServer.stop();
     }
 
+    public void waitForEmailThatMatches(Predicate<SmtpMessage> matches, String expected) {
+        List<SmtpMessage> receivedEmails = emptyList();
+        for (int counter = 0; counter < 10; counter++) {
+            receivedEmails = smtpServer.getReceivedEmails();
+            if (receivedEmails.stream().anyMatch(matches)) {
+                return;
+            }
+            try {
+                Thread.sleep(100L);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        String emails = receivedEmails.stream()
+                .map(email -> "To=\"" + email.getHeaderValue("To") + "\" Subject=\"" + email.getHeaderValue("Subject") + "\"")
+                .collect(Collectors.joining("}\n\t{", "\t{", "}"));
+
+        Assert.fail("Expected an email that matches " + expected + "\n" +
+                " But got " + emails);
+    }
+
     public void hasEmailWithSubjectAndAttachment(String subject, byte[] attachment) {
-        List<SmtpMessage> receivedEmails = smtpServer.getReceivedEmails();
-
-        assertThat(receivedEmails, new TypeSafeMatcher<List<SmtpMessage>>() {
-            @Override
-            protected boolean matchesSafely(List<SmtpMessage> smtpMessages) {
-                return receivedEmails.stream()
-                        .anyMatch(receivedEmail -> subject.equals(receivedEmail.getHeaderValue("Subject")) &&
-                                receivedEmail.getBody().contains(Arrays.toString(attachment)));
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("An email with a subject ").appendValue(subject);
-            }
-
-            @Override
-            protected void describeMismatchSafely(List<SmtpMessage> item, Description mismatchDescription) {
-                List<String> emailSubjects = item.stream().map(email -> email.getHeaderValue("Subject")).collect(toList());
-                mismatchDescription.appendText(" got").appendValue(emailSubjects);
-            }
-        });
+        waitForEmailThatMatches(receivedEmail -> subject.equals(
+            receivedEmail.getHeaderValue("Subject")) && receivedEmail.getBody().contains(Arrays.toString(attachment)),
+            "An email with a subject [" + subject + "] with attachment"
+        );
     }
 
     public void hasEmailWithSubject(String subject) {
-        List<SmtpMessage> receivedEmails = smtpServer.getReceivedEmails();
-
-        assertThat(receivedEmails, new TypeSafeMatcher<List<SmtpMessage>>() {
-            @Override
-            protected boolean matchesSafely(List<SmtpMessage> smtpMessages) {
-                return receivedEmails.stream()
-                        .anyMatch(receivedEmail -> subject.equals(receivedEmail.getHeaderValue("Subject")));
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("An email with a subject ").appendValue(subject);
-            }
-
-            @Override
-            protected void describeMismatchSafely(List<SmtpMessage> item, Description mismatchDescription) {
-                List<String> emailSubjects = item.stream().map(email -> email.getHeaderValue("Subject")).collect(toList());
-                mismatchDescription.appendText(" got").appendValue(emailSubjects);
-            }
-        });
+        waitForEmailThatMatches(
+            receivedEmail -> subject.equals(receivedEmail.getHeaderValue("Subject")),
+            "An email with a subject [" + subject + "]"
+        );
     }
 
     public void hasEmailWithSubject(String toAddress, String subject) {
-        List<SmtpMessage> receivedEmails = smtpServer.getReceivedEmails();
-
-        assertThat(receivedEmails, new TypeSafeMatcher<List<SmtpMessage>>() {
-            @Override
-            protected boolean matchesSafely(List<SmtpMessage> smtpMessages) {
-                return receivedEmails.stream()
-                        .anyMatch(receivedEmail -> subject.equals(receivedEmail.getHeaderValue("Subject")) &&
-                                toAddress.equals(receivedEmail.getHeaderValue("To")));
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("An email being sent to ").appendValue(toAddress)
-                        .appendText("with a subject ").appendValue(subject);
-            }
-
-            @Override
-            protected void describeMismatchSafely(List<SmtpMessage> item, Description mismatchDescription) {
-                List<String> emails = item.stream().map(email -> email.getHeaderValue("To") + " " + email.getHeaderValue("Subject")).collect(toList());
-                mismatchDescription.appendText(" got").appendValue(emails);
-            }
-        });
+        waitForEmailThatMatches(
+            receivedEmail -> subject.equals(receivedEmail.getHeaderValue("Subject")) && toAddress.equals(receivedEmail.getHeaderValue("To")),
+            "An email sent to [" + toAddress + "] with a subject [" + subject + "]"
+        );
     }
 
     public void hasNoEmails() {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/NotificationsStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/NotificationsStub.java
@@ -14,7 +14,7 @@ public class NotificationsStub extends BaseStub {
     }
 
     public void verifySendNotification(String cohEvent) {
-        wireMock.verify(postRequestedFor(urlEqualTo("/coh-send"))
+        verifyAsync(postRequestedFor(urlEqualTo("/coh-send"))
                 .withRequestBody(equalToJson(cohEvent))
         );
     }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/PdfServiceStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/PdfServiceStub.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.stubs;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,7 +37,7 @@ public class PdfServiceStub extends BaseStub {
         InputStream in = getClass().getResourceAsStream(pdfTemplate);
         byte[] templateBytes = IOUtils.toByteArray(in);
 
-        wireMock.verify(postRequestedFor(urlEqualTo("/pdfs"))
+        verifyAsync(postRequestedFor(urlEqualTo("/pdfs"))
                 .withRequestBody(matchingJsonPath(caseReferencePath, equalTo(caseReference)))
                 .withRequestBody(matchingJsonPath("$.template", equalTo(new String(templateBytes))))
         );

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/Application.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.client.RestTemplate;
@@ -33,7 +34,7 @@ import uk.gov.hmcts.reform.sscs.ccd.config.CcdRequestDetails;
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 @ComponentScan(basePackages = {"uk.gov.hmcts.reform"})
 @EnableAsync
-public class Application {
+public class Application implements AsyncConfigurer {
 
     public static void main(final String[] args) {
         SpringApplication.run(Application.class, args);
@@ -85,10 +86,11 @@ public class Application {
     }
 
     @Bean
-    public Executor taskExecutor() {
+    @Override
+    public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(2);
-        executor.setMaxPoolSize(2);
+        executor.setMaxPoolSize(4);
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("COHEventHandler-");
         executor.initialize();

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/Application.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
 import java.util.Properties;
+import java.util.concurrent.Executor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -10,6 +11,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
@@ -29,6 +32,7 @@ import uk.gov.hmcts.reform.sscs.ccd.config.CcdRequestDetails;
         })
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 @ComponentScan(basePackages = {"uk.gov.hmcts.reform"})
+@EnableAsync
 public class Application {
 
     public static void main(final String[] args) {
@@ -78,5 +82,16 @@ public class Application {
         properties.put("mail.smtp.ssl.trust","*");
         javaMailSender.setJavaMailProperties(properties);
         return javaMailSender;
+    }
+
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("COHEventHandler-");
+        executor.initialize();
+        return executor;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/Application.java
@@ -1,9 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend;
 
 import java.util.Properties;
-import java.util.concurrent.Executor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -13,17 +10,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
-import org.springframework.scheduling.annotation.AsyncConfigurer;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 import uk.gov.hmcts.reform.sscs.ccd.config.CcdRequestDetails;
-import uk.gov.hmcts.reform.sscscorbackend.exception.SscsCorBackendException;
-
 
 @SpringBootApplication
 @EnableCircuitBreaker
@@ -37,9 +28,7 @@ import uk.gov.hmcts.reform.sscscorbackend.exception.SscsCorBackendException;
         })
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 @ComponentScan(basePackages = {"uk.gov.hmcts.reform"})
-@EnableAsync
-@Slf4j
-public class Application implements AsyncConfigurer {
+public class Application {
 
     public static void main(final String[] args) {
         SpringApplication.run(Application.class, args);
@@ -88,25 +77,5 @@ public class Application implements AsyncConfigurer {
         properties.put("mail.smtp.ssl.trust","*");
         javaMailSender.setJavaMailProperties(properties);
         return javaMailSender;
-    }
-
-    @Bean
-    @Override
-    public Executor getAsyncExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(2);
-        executor.setMaxPoolSize(4);
-        executor.setQueueCapacity(500);
-        executor.setThreadNamePrefix("COHEventHandler-");
-        executor.initialize();
-        return executor;
-    }
-
-    @Override
-    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
-        return (ex, method, params) -> {
-            SscsCorBackendException exc = new SscsCorBackendException(AlertLevel.P3, ex);
-            log.error("Unhandled in COH thread exception", exc);
-        };
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/config/AsyncConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/config/AsyncConfiguration.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.sscscorbackend.config;
+
+import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.sscscorbackend.exception.SscsCorBackendException;
+
+@Configuration
+@EnableAsync
+@Slf4j
+public class AsyncConfiguration implements AsyncConfigurer {
+    @Bean
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("COHEventHandler-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) -> {
+            SscsCorBackendException exc = new SscsCorBackendException(AlertLevel.P3, ex);
+            log.error("Unhandled in COH thread exception", exc);
+        };
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
@@ -5,6 +5,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
@@ -18,10 +19,12 @@ public class CohEventActionMapper {
     private final ExecutorService executorService;
 
     @Autowired
-    public CohEventActionMapper(List<CohEventAction> actions, NotificationsService notificationService) {
+    public CohEventActionMapper(List<CohEventAction> actions,
+                                NotificationsService notificationService,
+                                @Value("${enable_coh_event_thread_pool}") Boolean enableCohEventThreadPool) {
         this.actions = actions;
         this.notificationService = notificationService;
-        executorService = Executors.newFixedThreadPool(3);
+        executorService = enableCohEventThreadPool ? Executors.newFixedThreadPool(3) : null;
     }
 
     private CohEventAction getActionFor(CohEvent event) {
@@ -34,25 +37,40 @@ public class CohEventActionMapper {
     public boolean handle(CohEvent event) {
         CohEventAction cohEventAction = getActionFor(event);
         if (cohEventAction != null) {
-            executorService.execute(() -> {
-                String onlineHearingId = event.getOnlineHearingId();
-                Long caseId = Long.valueOf(event.getCaseId());
-
-                try {
-                    log.info("Storing pdf [" + caseId + "]");
-                    StorePdfResult storePdfResult = cohEventAction.getPdfService().storePdf(caseId, onlineHearingId);
-                    log.info("Handle coh event [" + caseId + "]");
-                    cohEventAction.handle(caseId, onlineHearingId, storePdfResult);
-                    log.info("Notify appellant [" + caseId + "]");
-                    if (cohEventAction.notifyAppellant()) {
-                        notificationService.send(event);
+            if (executorService != null) {
+                executorService.execute(() -> {
+                    String onlineHearingId = event.getOnlineHearingId();
+                    String caseId = event.getCaseId();
+                    try {
+                        log.info("Handle COH event [" + event.getEventType() + "] " +
+                                "in new thread for case id [" + caseId + "] " +
+                                "online hearing id [" + onlineHearingId + "]");
+                        runAction(event, cohEventAction);
+                    } catch (Exception exc) {
+                        log.error("Error processing COH event for case id [" + caseId + "] " +
+                                "online hearing id [" + onlineHearingId + "]", exc);
                     }
-                } catch (Exception exc) {
-                    log.error("Error processing COH event for case id [" + caseId + "] online hearing id [" + onlineHearingId + "]", exc);
-                }
-            });
+                });
+            } else {
+                runAction(event, cohEventAction);
+            }
             return true;
         }
         return false;
     }
+
+    private void runAction(CohEvent event, CohEventAction cohEventAction) {
+        String onlineHearingId = event.getOnlineHearingId();
+        Long caseId = Long.valueOf(event.getCaseId());
+
+        log.info("Storing pdf [" + caseId + "]");
+        StorePdfResult storePdfResult = cohEventAction.getPdfService().storePdf(caseId, onlineHearingId);
+        log.info("Handle coh event [" + caseId + "]");
+        cohEventAction.handle(caseId, onlineHearingId, storePdfResult);
+        log.info("Notify appellant [" + caseId + "]");
+        if (cohEventAction.notifyAppellant()) {
+            notificationService.send(event);
+        }
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
@@ -1,30 +1,26 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
 @Slf4j
 @Service
 public class CohEventActionMapper {
     private final List<CohEventAction> actions;
-    private final NotificationsService notificationService;
-    private final ExecutorService executorService;
+    private final CohEventActionRunner cohEventActionRunner;
+    private final Boolean enableCohEventThreadPool;
 
     @Autowired
     public CohEventActionMapper(List<CohEventAction> actions,
-                                NotificationsService notificationService,
+                                CohEventActionRunner cohEventActionRunner,
                                 @Value("${enable_coh_event_thread_pool}") Boolean enableCohEventThreadPool) {
         this.actions = actions;
-        this.notificationService = notificationService;
-        executorService = enableCohEventThreadPool ? Executors.newFixedThreadPool(3) : null;
+        this.cohEventActionRunner = cohEventActionRunner;
+        this.enableCohEventThreadPool = enableCohEventThreadPool;
     }
 
     private CohEventAction getActionFor(CohEvent event) {
@@ -37,40 +33,15 @@ public class CohEventActionMapper {
     public boolean handle(CohEvent event) {
         CohEventAction cohEventAction = getActionFor(event);
         if (cohEventAction != null) {
-            if (executorService != null) {
-                executorService.execute(() -> {
-                    String onlineHearingId = event.getOnlineHearingId();
-                    String caseId = event.getCaseId();
-                    try {
-                        log.info("Handle COH event [" + event.getEventType() + "] " +
-                                "in new thread for case id [" + caseId + "] " +
-                                "online hearing id [" + onlineHearingId + "]");
-                        runAction(event, cohEventAction);
-                    } catch (Exception exc) {
-                        log.error("Error processing COH event for case id [" + caseId + "] " +
-                                "online hearing id [" + onlineHearingId + "]", exc);
-                    }
-                });
+            if (enableCohEventThreadPool) {
+                cohEventActionRunner.runActionAsync(event, cohEventAction);
             } else {
-                runAction(event, cohEventAction);
+                cohEventActionRunner.runActionSync(event, cohEventAction);
             }
+            log.info("Carrying on for [" + event.getCaseId() + "]");
             return true;
         }
         return false;
-    }
-
-    private void runAction(CohEvent event, CohEventAction cohEventAction) {
-        String onlineHearingId = event.getOnlineHearingId();
-        Long caseId = Long.valueOf(event.getCaseId());
-
-        log.info("Storing pdf [" + caseId + "]");
-        StorePdfResult storePdfResult = cohEventAction.getPdfService().storePdf(caseId, onlineHearingId);
-        log.info("Handle coh event [" + caseId + "]");
-        cohEventAction.handle(caseId, onlineHearingId, storePdfResult);
-        log.info("Notify appellant [" + caseId + "]");
-        if (cohEventAction.notifyAppellant()) {
-            notificationService.send(event);
-        }
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionRunner.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
+
+@Component
+@Slf4j
+public class CohEventActionRunner {
+    private final NotificationsService notificationService;
+
+    public CohEventActionRunner(NotificationsService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    public void runActionSync(CohEvent event, CohEventAction cohEventAction) {
+        String onlineHearingId = event.getOnlineHearingId();
+        Long caseId = Long.valueOf(event.getCaseId());
+
+        log.info("Storing pdf [" + caseId + "]");
+        StorePdfResult storePdfResult = cohEventAction.getPdfService().storePdf(caseId, onlineHearingId);
+        log.info("Handle coh event [" + caseId + "]");
+        cohEventAction.handle(caseId, onlineHearingId, storePdfResult);
+        log.info("Notify appellant [" + caseId + "]");
+        if (cohEventAction.notifyAppellant()) {
+            notificationService.send(event);
+        }
+    }
+
+    @Async
+    public void runActionAsync(CohEvent event, CohEventAction cohEventAction) {
+        runActionSync(event, cohEventAction);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,6 +85,7 @@ appeal:
 
 enable_debug_error_message: ${ENABLE_DEBUG_ERROR_MESSAGE:true}
 enable_select_by_case_id: ${ENABLE_SELECT_BY_CASE_ID:false}
+enable_coh_event_thread_pool: ${ENABLE_COH_EVENT_THREAD_POOL:false}
 
 feign:
   client:

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionRunnerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionRunnerTest.java
@@ -1,0 +1,83 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import static java.lang.Long.valueOf;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someCohEvent;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
+
+public class CohEventActionRunnerTest {
+
+    private NotificationsService notificationService;
+    private CohEventAction cohEventAction;
+    private String hearingId;
+    private CohEvent cohEvent;
+    private StorePdfService storePdfService;
+    private StorePdfResult storePdfResult;
+    private Long caseIdLong;
+    private CohEventActionRunner cohEventActionRunner;
+
+    @Before
+    public void setUp() {
+        notificationService = mock(NotificationsService.class);
+        cohEventAction = mock(CohEventAction.class);
+        String caseId = "123456";
+        hearingId = "hearingId";
+        cohEvent = someCohEvent(caseId, hearingId, "some-event");
+        storePdfService = mock(StorePdfService.class);
+        when(cohEventAction.getPdfService()).thenReturn(storePdfService);
+        storePdfResult = mock(StorePdfResult.class);
+        caseIdLong = valueOf(caseId);
+        when(storePdfService.storePdf(caseIdLong, hearingId)).thenReturn(storePdfResult);
+        cohEventActionRunner = new CohEventActionRunner(notificationService);
+    }
+
+    @Test
+    public void syncStoresPdfHandlesActionAndSendNotificaiton() {
+        when(cohEventAction.notifyAppellant()).thenReturn(true);
+
+        cohEventActionRunner.runActionSync(cohEvent, cohEventAction);
+
+        verify(storePdfService).storePdf(caseIdLong, hearingId);
+        verify(cohEventAction).handle(caseIdLong, hearingId, storePdfResult);
+        verify(notificationService).send(cohEvent);
+    }
+
+    @Test
+    public void syncStoresPdfHandlesActionAndDoesNotSendNotificaiton() {
+        when(cohEventAction.notifyAppellant()).thenReturn(false);
+
+        cohEventActionRunner.runActionSync(cohEvent, cohEventAction);
+
+        verify(storePdfService).storePdf(caseIdLong, hearingId);
+        verify(cohEventAction).handle(caseIdLong, hearingId, storePdfResult);
+        verifyZeroInteractions(notificationService);
+    }
+
+    @Test
+    public void asyncStoresPdfHandlesActionAndSendNotificaiton() {
+        when(cohEventAction.notifyAppellant()).thenReturn(true);
+
+        cohEventActionRunner.runActionAsync(cohEvent, cohEventAction);
+
+        verify(storePdfService).storePdf(caseIdLong, hearingId);
+        verify(cohEventAction).handle(caseIdLong, hearingId, storePdfResult);
+        verify(notificationService).send(cohEvent);
+    }
+
+    @Test
+    public void asyncStoresPdfHandlesActionAndDoesNotSendNotificaiton() {
+        when(cohEventAction.notifyAppellant()).thenReturn(false);
+
+        cohEventActionRunner.runActionAsync(cohEvent, cohEventAction);
+
+        verify(storePdfService).storePdf(caseIdLong, hearingId);
+        verify(cohEventAction).handle(caseIdLong, hearingId, storePdfResult);
+        verifyZeroInteractions(notificationService);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventCohEventActionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventCohEventActionMapperTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.Notifications
 
 public class CohEventCohEventActionMapperTest {
 
+    private static final int TIMOUT_FOR_METHOD_CALL_MILLIS = 5000;
     private CohEventActionMapper cohEventActionMapper;
     private CohEventAction action;
     private NotificationsService notificationService;
@@ -47,9 +48,9 @@ public class CohEventCohEventActionMapperTest {
         CohEvent cohEvent = someCohEvent(caseId, hearingId, "someMappedEvent");
         boolean handle = cohEventActionMapper.handle(cohEvent);
 
-        verify(action).handle(caseIdLong, hearingId, storePdfResult);
-        verify(storePdfService).storePdf(caseIdLong, hearingId);
-        verify(notificationService).send(cohEvent);
+        verify(action, timeout(TIMOUT_FOR_METHOD_CALL_MILLIS)).handle(caseIdLong, hearingId, storePdfResult);
+        verify(storePdfService, timeout(TIMOUT_FOR_METHOD_CALL_MILLIS)).storePdf(caseIdLong, hearingId);
+        verify(notificationService, timeout(TIMOUT_FOR_METHOD_CALL_MILLIS)).send(cohEvent);
         assertThat(handle, is(true));
     }
 
@@ -59,10 +60,10 @@ public class CohEventCohEventActionMapperTest {
         CohEvent cohEvent = someCohEvent(caseId, hearingId, "someMappedEvent");
         boolean handle = cohEventActionMapper.handle(cohEvent);
 
-        verify(action).handle(caseIdLong, hearingId, storePdfResult);
-        verify(storePdfService).storePdf(caseIdLong, hearingId);
-        verifyZeroInteractions(notificationService);
         assertThat(handle, is(true));
+        verify(action, timeout(TIMOUT_FOR_METHOD_CALL_MILLIS)).handle(caseIdLong, hearingId, storePdfResult);
+        verify(storePdfService, timeout(TIMOUT_FOR_METHOD_CALL_MILLIS)).storePdf(caseIdLong, hearingId);
+        verifyZeroInteractions(notificationService);
     }
 
     @Test
@@ -70,8 +71,8 @@ public class CohEventCohEventActionMapperTest {
         CohEvent cohEvent = someCohEvent(caseId, hearingId, "someUnMappedEvent");
         boolean handle = cohEventActionMapper.handle(cohEvent);
 
-        verify(action, never()).handle(any(Long.class), any(String.class), any(StorePdfResult.class));
-        verifyZeroInteractions(notificationService);
         assertThat(handle, is(false));
+        verify(action, timeout(TIMOUT_FOR_METHOD_CALL_MILLIS).times(0)).handle(any(Long.class), any(String.class), any(StorePdfResult.class));
+        verifyZeroInteractions(notificationService);
     }
 }


### PR DESCRIPTION
Currently we can take a long time to handle COH events as we do
a number of things.
- Create PDFs
- Send the PDFs to DWP
- Update the CCD case
- Notify the appellant.

Now when we get a COH event return ok to COH and handle the event
in a new thread. Use a fixed sized ThreadPoolExecutor to handle
the events.