### PR TITLE
SSCS-4478 Update CCD with COH events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ dependencies {
   compileOnly 'org.projectlombok:lombok:1.18.6'
   compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.2.4.RELEASE'
   compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.5.0'
-  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.138'
+  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.141'
 
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.104'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '4.0.2'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
@@ -82,15 +82,19 @@ public class CcdStub extends BaseStub {
                 .willReturn(okJson(new ObjectMapper().writeValueAsString(CaseDetails.builder().build()))));
     }
 
-    public void stubUpdateCaseWithEvent(Long caseId) throws JsonProcessingException {
-        wireMock.stubFor(get("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/event-triggers/updateHearingType/token")
+    public void stubUpdateCaseWithEvent(Long caseId, final String eventType) throws JsonProcessingException {
+        wireMock.stubFor(get("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/event-triggers/" + eventType + "/token")
                 .willReturn(okJson(new ObjectMapper().writeValueAsString(StartEventResponse.builder().build()))));
 
         wireMock.stubFor(post("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/events?ignore-warning=true")
                 .willReturn(okJson(new ObjectMapper().writeValueAsString(CaseDetails.builder().build()))));
     }
 
-    public void verifyUpdateCaseWithPdf(Long caseId, String caseReference, String pdfName) throws JsonProcessingException {
+    public void verifyUpdateCaseWithEvent(Long caseId, String eventType) {
+        verifyAsync(getRequestedFor(urlEqualTo("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/event-triggers/" + eventType + "/token")));
+    }
+
+    public void verifyUpdateCaseWithPdf(Long caseId, String caseReference, String pdfName) {
         verifyAsync(postRequestedFor(urlEqualTo("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/events?ignore-warning=true"))
                 .withRequestBody(matchingJsonPath("$.event.summary", equalTo("SSCS - appeal updated event")))
                 .withRequestBody(matchingJsonPath("$.data.caseReference", equalTo(caseReference)))

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/NotificationsStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/NotificationsStub.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend.stubs;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 
 public class NotificationsStub extends BaseStub {
     public NotificationsStub(String url) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventAction.java
@@ -1,14 +1,19 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
-import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 public interface CohEventAction {
-    void handle(Long caseId, String onlineHearingId, StorePdfResult storePdfResult);
+    String cohEvent();
 
-    String eventCanHandle();
+    default CohEventActionContext createAndStorePdf(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
+        return new CohEventActionContext(null, caseDetails);
+    }
 
-    StorePdfService getPdfService();
+    CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext);
+
+    EventType getCcdEventType();
 
     default boolean notifyAppellant() {
         return true;

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionMapper.java
@@ -25,7 +25,7 @@ public class CohEventActionMapper {
 
     private CohEventAction getActionFor(CohEvent event) {
         return actions.stream()
-                .filter(action -> action.eventCanHandle().equals(event.getEventType()))
+                .filter(action -> action.cohEvent().equals(event.getEventType()))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventActionRunner.java
@@ -3,16 +3,24 @@ package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.apinotifications.CohEvent;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.notifications.NotificationsService;
 
 @Component
 @Slf4j
 public class CohEventActionRunner {
+    private final CorCcdService corCcdService;
+    private final IdamService idamService;
     private final NotificationsService notificationService;
 
-    public CohEventActionRunner(NotificationsService notificationService) {
+    public CohEventActionRunner(CorCcdService corCcdService, IdamService idamService, NotificationsService notificationService) {
+        this.corCcdService = corCcdService;
+        this.idamService = idamService;
         this.notificationService = notificationService;
     }
 
@@ -20,18 +28,37 @@ public class CohEventActionRunner {
         String onlineHearingId = event.getOnlineHearingId();
         Long caseId = Long.valueOf(event.getCaseId());
 
+        SscsCaseDetails sscsCaseDetails = loadCcdCaseDetails(caseId);
         log.info("Storing pdf [" + caseId + "]");
-        StorePdfResult storePdfResult = cohEventAction.getPdfService().storePdf(caseId, onlineHearingId);
+        CohEventActionContext storePdfResultStorePdf = cohEventAction.createAndStorePdf(caseId, onlineHearingId, sscsCaseDetails);
         log.info("Handle coh event [" + caseId + "]");
-        cohEventAction.handle(caseId, onlineHearingId, storePdfResult);
+        CohEventActionContext cohEventActionContextHandle = cohEventAction.handle(caseId, onlineHearingId, storePdfResultStorePdf);
         log.info("Notify appellant [" + caseId + "]");
+
         if (cohEventAction.notifyAppellant()) {
             notificationService.send(event);
         }
+
+        corCcdService.updateCase(
+                cohEventActionContextHandle.getDocument().getData(),
+                caseId,
+                cohEventAction.getCcdEventType().getCcdType(),
+                "SSCS COH - Event received",
+                "Coh event [" + cohEventAction.cohEvent() + "] received",
+                idamService.getIdamTokens());
     }
 
     @Async
     public void runActionAsync(CohEvent event, CohEventAction cohEventAction) {
         runActionSync(event, cohEventAction);
+    }
+
+    private SscsCaseDetails loadCcdCaseDetails(long caseId) {
+        IdamTokens idamTokens = idamService.getIdamTokens();
+        log.info("Loading case [" + caseId + "]");
+        SscsCaseDetails caseDetails = corCcdService.getByCaseId(caseId, idamTokens);
+        log.info("Loaded case [" + caseId + "]");
+
+        return caseDetails;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineElapsedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineElapsedEventAction.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+@Service
+public class DeadlineElapsedEventAction implements CohEventAction {
+    @Override
+    public String cohEvent() {
+        return "question_deadline_elapsed";
+    }
+
+    @Override
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
+        return cohEventActionContext;
+    }
+
+    @Override
+    public EventType getCcdEventType() {
+        return EventType.COH_QUESTION_DEADLINE_ELAPSED;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineExtendedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineExtendedEventAction.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+@Service
+public class DeadlineExtendedEventAction implements CohEventAction {
+    @Override
+    public String cohEvent() {
+        return "question_deadline_extended";
+    }
+
+    @Override
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
+        return cohEventActionContext;
+    }
+
+    @Override
+    public EventType getCcdEventType() {
+        return EventType.COH_QUESTION_DEADLINE_EXTENDED;
+    }
+
+    @Override
+    public boolean notifyAppellant() {
+        return false;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineExtensionDeniedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineExtensionDeniedEventAction.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+@Service
+public class DeadlineExtensionDeniedEventAction implements CohEventAction {
+    @Override
+    public String cohEvent() {
+        return "question_deadline_extension_denied";
+    }
+
+    @Override
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
+        return cohEventActionContext;
+    }
+
+    @Override
+    public EventType getCcdEventType() {
+        return EventType.COH_QUESTION_DEADLINE_EXTENSION_DENIED;
+    }
+
+    @Override
+    public boolean notifyAppellant() {
+        return false;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineExtensionGrantedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineExtensionGrantedEventAction.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+@Service
+public class DeadlineExtensionGrantedEventAction implements CohEventAction {
+    @Override
+    public String cohEvent() {
+        return "question_deadline_extension_granted";
+    }
+
+    @Override
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
+        return cohEventActionContext;
+    }
+
+    @Override
+    public EventType getCcdEventType() {
+        return EventType.COH_QUESTION_DEADLINE_EXTENSION_GRANTED;
+    }
+
+    @Override
+    public boolean notifyAppellant() {
+        return false;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineReminderEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineReminderEventAction.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+@Service
+public class DeadlineReminderEventAction implements CohEventAction {
+    @Override
+    public String cohEvent() {
+        return "question_deadline_reminder";
+    }
+
+    @Override
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
+        return cohEventActionContext;
+    }
+
+    @Override
+    public EventType getCcdEventType() {
+        return EventType.COH_QUESTION_DEADLINE_REMINDER;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionRejectedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionRejectedEventAction.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+@Service
+public class DecisionRejectedEventAction implements CohEventAction {
+    @Override
+    public String cohEvent() {
+        return "decision_rejected";
+    }
+
+    @Override
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
+        return cohEventActionContext;
+    }
+
+    @Override
+    public EventType getCcdEventType() {
+        return EventType.COH_DECISION_REJECTED;
+    }
+
+    @Override
+    public boolean notifyAppellant() {
+        return false;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AbstractQuestionPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AbstractQuestionPdfService.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
@@ -17,11 +16,10 @@ public abstract class AbstractQuestionPdfService extends StorePdfService<PdfQues
             PdfService pdfService,
             String templatePath,
             SscsPdfService sscsPdfService,
-            CcdService ccdService,
             IdamService idamService,
             QuestionService questionService,
             EvidenceManagementService evidenceManagementService) {
-        super(pdfService, templatePath, sscsPdfService, ccdService, idamService, evidenceManagementService);
+        super(pdfService, templatePath, sscsPdfService, idamService, evidenceManagementService);
         this.questionService = questionService;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CorEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CorEmailService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.domain.email.Email;
 import uk.gov.hmcts.reform.sscs.domain.email.EmailAttachment;
 import uk.gov.hmcts.reform.sscs.service.EmailService;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 @Slf4j
 @Service
@@ -28,15 +28,15 @@ public class CorEmailService {
         this.dwpEmailAddress = dwpEmailAddress;
     }
 
-    public void sendPdfToDwp(StorePdfResult storePdfResult, String subject, String message) {
-        byte[] content = storePdfResult.getPdf().getContent();
+    public void sendPdfToDwp(CohEventActionContext cohEventActionContext, String subject, String message) {
+        byte[] content = cohEventActionContext.getPdf().getContent();
         log.info("Sending email and PDf with subject [" + subject + "] to DWP");
         emailService.sendEmail(Email.builder()
                 .from(fromEmailAddress)
                 .to(dwpEmailAddress)
                 .subject(subject)
                 .message(message)
-                .attachments(asList(EmailAttachment.pdf(content, storePdfResult.getPdf().getName())))
+                .attachments(asList(EmailAttachment.pdf(content, cohEventActionContext.getPdf().getName())))
                 .build());
     }
 
@@ -59,5 +59,4 @@ public class CorEmailService {
                 .message(message)
                 .build());
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersPdfService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.sscscorbackend.service;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
@@ -17,11 +16,10 @@ public class StoreAnswersPdfService extends AbstractQuestionPdfService {
             PdfService pdfService,
             @Value("${answer.html.template.path}") String templatePath,
             SscsPdfService sscsPdfService,
-            CcdService ccdService,
             IdamService idamService,
             QuestionService questionService,
             EvidenceManagementService evidenceManagementService) {
-        super(pdfService, templatePath, sscsPdfService, ccdService, idamService, questionService, evidenceManagementService);
+        super(pdfService, templatePath, sscsPdfService, idamService, questionService, evidenceManagementService);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingService.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
@@ -24,13 +23,12 @@ public class StoreOnlineHearingService extends StorePdfService<PdfSummary> {
     @SuppressWarnings("squid:S00107")
     public StoreOnlineHearingService(CohService cohService,
                                      IdamService idamService,
-                                     CcdService ccdService,
                                      PdfSummaryBuilder pdfSummaryBuilder,
                                      SscsPdfService sscsPdfService,
                                      PdfService pdfService,
                                      @Value("${online_hearing_finished.html.template.path}") String templatePath,
                                      EvidenceManagementService evidenceManagementService) {
-        super(pdfService, templatePath, sscsPdfService, ccdService, idamService, evidenceManagementService);
+        super(pdfService, templatePath, sscsPdfService, idamService, evidenceManagementService);
         this.cohService = cohService;
         this.pdfSummaryBuilder = pdfSummaryBuilder;
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewService.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
@@ -26,9 +25,9 @@ public class StoreOnlineHearingTribunalsViewService extends StorePdfService<Onli
                                                   PdfService pdfService,
                                                   @Value("${preliminary_view.html.template.path}") String templatePath,
                                                   OnlineHearingDateReformatter onlineHearingDateReformatter,
-                                                  SscsPdfService sscsPdfService, CcdService ccdService, IdamService idamService,
+                                                  SscsPdfService sscsPdfService, IdamService idamService,
                                                   EvidenceManagementService evidenceManagementService) {
-        super(pdfService, templatePath, sscsPdfService, ccdService, idamService, evidenceManagementService);
+        super(pdfService, templatePath, sscsPdfService, idamService, evidenceManagementService);
         this.onlineHearingService = onlineHearingService;
         this.onlineHearingDateReformatter = onlineHearingDateReformatter;
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreQuestionsPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreQuestionsPdfService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.sscscorbackend.service;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
@@ -17,11 +16,10 @@ public class StoreQuestionsPdfService extends AbstractQuestionPdfService {
             PdfService pdfService,
             @Value("${question.html.template.path}") String templatePath,
             SscsPdfService sscsPdfService,
-            CcdService ccdService,
             IdamService idamService,
             QuestionService questionService,
             EvidenceManagementService evidenceManagementService) {
-        super(pdfService, templatePath, sscsPdfService, ccdService, idamService, questionService, evidenceManagementService);
+        super(pdfService, templatePath, sscsPdfService, idamService, questionService, evidenceManagementService);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/CohEventActionContext.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/CohEventActionContext.java
@@ -2,11 +2,11 @@ package uk.gov.hmcts.reform.sscscorbackend.service.pdf;
 
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 
-public class StorePdfResult {
+public class CohEventActionContext {
     private final Pdf pdf;
     private final SscsCaseDetails document;
 
-    public StorePdfResult(Pdf pdf, SscsCaseDetails document) {
+    public CohEventActionContext(Pdf pdf, SscsCaseDetails document) {
         this.pdf = pdf;
         this.document = document;
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -17,8 +17,8 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfQuestion;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfQuestionRound;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfSummary;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.Pdf;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.apinotifications.CaseData;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.apinotifications.CaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.apinotifications.CcdEvent;
@@ -141,8 +141,8 @@ public class DataFixtures {
         );
     }
 
-    public static StorePdfResult someStorePdfResult() {
-        return new StorePdfResult(
+    public static CohEventActionContext someStorePdfResult() {
+        return new CohEventActionContext(
                 new Pdf(new byte[]{2, 4, 6, 0, 1}, "pdfName.pdf"),
                 SscsCaseDetails.builder()
                         .data(SscsCaseData.builder()

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventActionTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;
@@ -8,8 +10,8 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreAnswersPdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.Pdf;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 
 public class AnswerSubmittedEventActionTest {
     @Test
@@ -27,11 +29,12 @@ public class AnswerSubmittedEventActionTest {
         long caseId = 123L;
         String onlineHearingId = "onlineHearingId";
         String pdfName = "pdf_name.pdf";
-        StorePdfResult storePdfResult = new StorePdfResult(new Pdf(new byte[]{2, 5, 6, 0, 1}, pdfName), caseDetails);
+        CohEventActionContext cohEventActionContext = new CohEventActionContext(new Pdf(new byte[]{2, 5, 6, 0, 1}, pdfName), caseDetails);
         when(dwpEmailMessageBuilder.getAnswerMessage(caseDetails)).thenReturn("some message");
 
-        answerSubmittedEventAction.handle(caseId, onlineHearingId, storePdfResult);
+        CohEventActionContext result = answerSubmittedEventAction.handle(caseId, onlineHearingId, cohEventActionContext);
 
-        verify(corEmailService).sendPdfToDwp(storePdfResult, "Appellant has provided information (" + someCaseReference + ")", "some message");
+        verify(corEmailService).sendPdfToDwp(cohEventActionContext, "Appellant has provided information (" + someCaseReference + ")", "some message");
+        assertThat(result, is(cohEventActionContext));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventCohEventActionMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/CohEventCohEventActionMapperTest.java
@@ -25,7 +25,7 @@ public class CohEventCohEventActionMapperTest {
         caseId = "1234";
         hearingId = "hearingId";
         action = mock(CohEventAction.class);
-        when(action.eventCanHandle()).thenReturn("someMappedEvent");
+        when(action.cohEvent()).thenReturn("someMappedEvent");
         actions = singletonList(action);
         cohEventActionRunner = mock(CohEventActionRunner.class);
         cohEventActionMapper = new CohEventActionMapper(actions, cohEventActionRunner, true);

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DecisionIssuedEventActionTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someStorePdfResult;
 
@@ -8,7 +10,7 @@ import org.junit.Test;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreOnlineHearingTribunalsViewService;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 public class DecisionIssuedEventActionTest {
 
@@ -32,15 +34,16 @@ public class DecisionIssuedEventActionTest {
     @Test
     public void canHandleEvent() {
         String message = "someMessage";
-        StorePdfResult storePdfResult = someStorePdfResult();
-        when(dwpEmailMessageBuilder.getDecisionIssuedMessage(storePdfResult.getDocument())).thenReturn(message);
+        CohEventActionContext cohEventActionContext = someStorePdfResult();
+        when(dwpEmailMessageBuilder.getDecisionIssuedMessage(cohEventActionContext.getDocument())).thenReturn(message);
 
         long caseId = 123L;
         String onlineHearingId = "onlineHearingId";
 
-        decisionIssuedEventAction.handle(caseId, onlineHearingId, storePdfResult);
+        CohEventActionContext result = decisionIssuedEventAction.handle(caseId, onlineHearingId, cohEventActionContext);
 
-        String subject = "Preliminary view offered (" + storePdfResult.getDocument().getData().getCaseReference() + ")";
-        verify(corEmailService).sendPdfToDwp(storePdfResult, subject, message);
+        String subject = "Preliminary view offered (" + cohEventActionContext.getDocument().getData().getCaseReference() + ")";
+        verify(corEmailService).sendPdfToDwp(cohEventActionContext, subject, message);
+        assertThat(result, is(cohEventActionContext));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundIssuedEventActionTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
 import org.junit.Before;
@@ -9,7 +11,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreQuestionsPdfService;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 public class QuestionRoundIssuedEventActionTest {
     private CorEmailService corEmailService;
@@ -32,19 +34,20 @@ public class QuestionRoundIssuedEventActionTest {
 
     @Test
     public void sendQuestionsToDwp() {
-        StorePdfResult storePdfResult = mock(StorePdfResult.class);
+        CohEventActionContext cohEventActionContext = mock(CohEventActionContext.class);
         String caseReference = "caseRef";
         SscsCaseDetails sscsCaseDetails = SscsCaseDetails.builder()
                 .data(SscsCaseData.builder()
                         .caseReference(caseReference)
                         .build())
                 .build();
-        when(storePdfResult.getDocument()).thenReturn(sscsCaseDetails);
+        when(cohEventActionContext.getDocument()).thenReturn(sscsCaseDetails);
         String message = "message";
         when(dwpEmailMessageBuilder.getQuestionMessage(sscsCaseDetails)).thenReturn(message);
 
-        questionRoundIssuedEventAction.handle(caseId, hearingId, storePdfResult);
+        CohEventActionContext result = questionRoundIssuedEventAction.handle(caseId, hearingId, cohEventActionContext);
 
-        verify(corEmailService).sendPdfToDwp(storePdfResult, "Questions issued to the appellant (" + caseReference + ")", message);
+        verify(corEmailService).sendPdfToDwp(cohEventActionContext, "Questions issued to the appellant (" + caseReference + ")", message);
+        assertThat(result, is(cohEventActionContext));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/CorEmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/CorEmailServiceTest.java
@@ -11,8 +11,8 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.domain.email.Email;
 import uk.gov.hmcts.reform.sscs.domain.email.EmailAttachment;
 import uk.gov.hmcts.reform.sscs.service.EmailService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.Pdf;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
 
 public class CorEmailServiceTest {
 
@@ -40,7 +40,7 @@ public class CorEmailServiceTest {
                 .build();
         String message = "Some message";
         String subject = "subject";
-        corEmailService.sendPdfToDwp(new StorePdfResult(new Pdf(pdfContent, pdfFileName), sscsCaseDetails), subject, message);
+        corEmailService.sendPdfToDwp(new CohEventActionContext(new Pdf(pdfContent, pdfFileName), sscsCaseDetails), subject, message);
 
         verify(emailService).sendEmail(Email.builder()
                 .from(fromEmailAddress)

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersPdfServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
@@ -28,7 +27,7 @@ public class StoreAnswersPdfServiceTest {
         questionService = mock(QuestionService.class);
         onlineHearingId = "someOnlineHearingId";
         storeQuestionsPdfService = new StoreAnswersPdfService(
-                mock(PdfService.class), "sometemplate", mock(SscsPdfService.class), mock(CcdService.class), mock(IdamService.class),
+                mock(PdfService.class), "sometemplate", mock(SscsPdfService.class), mock(IdamService.class),
                 questionService, mock(EvidenceManagementService.class));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
@@ -36,7 +35,7 @@ public class StoreOnlineHearingServiceTest {
         pdfSummaryBuilder = mock(PdfSummaryBuilder.class);
 
         underTest = new StoreOnlineHearingService(
-                cohService, mock(IdamService.class), mock(CcdService.class), pdfSummaryBuilder,
+                cohService, mock(IdamService.class), pdfSummaryBuilder,
                 mock(SscsPdfService.class), mock(PdfService.class), "sometemplate",
                 mock(EvidenceManagementService.class));
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewServiceTest.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
@@ -23,7 +22,6 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
     private PdfService pdfService;
     private StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService;
     private SscsPdfService sscsPdfService;
-    private CcdService ccdService;
     private IdamTokens idamTokens;
     private SscsCaseDetails sscsCaseDetails;
     private SscsCaseData sscsCaseData;
@@ -37,7 +35,6 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
         sscsPdfService = mock(SscsPdfService.class);
         sscsPdfService = mock(SscsPdfService.class);
         IdamService idamService = mock(IdamService.class);
-        ccdService = mock(CcdService.class);
         idamTokens = mock(IdamTokens.class);
         when(idamService.getIdamTokens()).thenReturn(idamTokens);
         storeOnlineHearingTribunalsViewService = new StoreOnlineHearingTribunalsViewService(
@@ -46,7 +43,6 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
                 "sometemplate",
                 onlineHearingDateReformatter,
                 sscsPdfService,
-                ccdService,
                 idamService,
                 mock(EvidenceManagementService.class));
         someHearingId = "someHearingId";
@@ -57,10 +53,8 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
         sscsCaseData = createSscsCaseData();
         sscsCaseDetails = SscsCaseDetails.builder().data(sscsCaseData).build();
 
-        when(ccdService.getByCaseId(someCaseId, idamTokens)).thenReturn(sscsCaseDetails);
-
         when(onlineHearingService.loadOnlineHearingFromCoh(sscsCaseDetails)).thenReturn(Optional.empty());
-        storeOnlineHearingTribunalsViewService.storePdf(someCaseId, someHearingId);
+        storeOnlineHearingTribunalsViewService.storePdf(someCaseId, someHearingId, sscsCaseDetails);
     }
 
     private SscsCaseData createSscsCaseData() {

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfServiceTest.java
@@ -10,13 +10,12 @@ import java.net.URISyntaxException;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StorePdfResult;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 public class StorePdfServiceTest {
@@ -29,7 +28,6 @@ public class StorePdfServiceTest {
 
     private PdfService pdfService;
     private SscsPdfService sscsPdfService;
-    private CcdService ccdService;
     private long caseId;
     private Object pdfContent;
     private String fileNamePrefix;
@@ -42,7 +40,6 @@ public class StorePdfServiceTest {
     public void setUp() {
         pdfService = mock(PdfService.class);
         sscsPdfService = mock(SscsPdfService.class);
-        ccdService = mock(CcdService.class);
         IdamService idamService = mock(IdamService.class);
         idamTokens = IdamTokens.builder().build();
         when(idamService.getIdamTokens()).thenReturn(idamTokens);
@@ -50,7 +47,7 @@ public class StorePdfServiceTest {
         pdfContent = new Object();
         fileNamePrefix = "test name";
         evidenceManagementService = mock(EvidenceManagementService.class);
-        storePdfService = new StorePdfService(pdfService, "sometemplate", sscsPdfService, ccdService, idamService, evidenceManagementService) {
+        storePdfService = new StorePdfService(pdfService, "sometemplate", sscsPdfService, idamService, evidenceManagementService) {
 
             @Override
             protected String documentNamePrefix(SscsCaseDetails caseDetails, String onlineHearingId) {
@@ -68,16 +65,15 @@ public class StorePdfServiceTest {
     @Test
     public void storePdf() {
         SscsCaseDetails caseDetails = createCaseDetails();
-        when(ccdService.getByCaseId(caseId, idamTokens)).thenReturn(caseDetails);
         byte[] expectedPdfBytes = {2, 4, 6, 0, 1};
         when(pdfService.createPdf(pdfContent, "sometemplate")).thenReturn(expectedPdfBytes);
 
-        StorePdfResult storePdfResult = storePdfService.storePdf(caseId, someOnlineHearingId);
+        CohEventActionContext cohEventActionContext = storePdfService.storePdf(caseId, someOnlineHearingId, caseDetails);
 
         verify(sscsPdfService).mergeDocIntoCcd(fileNamePrefix + CASE_REF + ".pdf", expectedPdfBytes, caseId, caseDetails.getData(), idamTokens);
-        assertThat(storePdfResult.getPdf().getContent(), is(expectedPdfBytes));
-        assertThat(storePdfResult.getPdf().getName(), is(fileNamePrefix + CASE_REF + ".pdf"));
-        assertThat(storePdfResult.getDocument(), is(caseDetails));
+        assertThat(cohEventActionContext.getPdf().getContent(), is(expectedPdfBytes));
+        assertThat(cohEventActionContext.getPdf().getName(), is(fileNamePrefix + CASE_REF + ".pdf"));
+        assertThat(cohEventActionContext.getDocument(), is(caseDetails));
     }
 
     @Test
@@ -99,16 +95,15 @@ public class StorePdfServiceTest {
                         .build()
                 ).build()).build()).build();
         SscsCaseDetails sscsCaseDetails = SscsCaseDetails.builder().data(sscsCaseData).build();
-        when(ccdService.getByCaseId(caseId, idamTokens)).thenReturn(sscsCaseDetails);
         byte[] expectedPdfBytes = {2, 4, 6, 0, 1};
         when(evidenceManagementService.download(new URI(documentUrl), "sscs")).thenReturn(expectedPdfBytes);
 
-        StorePdfResult storePdfResult = storePdfService.storePdf(caseId, someOnlineHearingId);
+        CohEventActionContext cohEventActionContext = storePdfService.storePdf(caseId, someOnlineHearingId, sscsCaseDetails);
 
         verifyZeroInteractions(sscsPdfService);
-        assertThat(storePdfResult.getPdf().getContent(), is(expectedPdfBytes));
-        assertThat(storePdfResult.getPdf().getName(), is(fileNamePrefix + CASE_REF + ".pdf"));
-        assertThat(storePdfResult.getDocument(), is(sscsCaseDetails));
+        assertThat(cohEventActionContext.getPdf().getContent(), is(expectedPdfBytes));
+        assertThat(cohEventActionContext.getPdf().getName(), is(fileNamePrefix + CASE_REF + ".pdf"));
+        assertThat(cohEventActionContext.getDocument(), is(sscsCaseDetails));
     }
 
     private SscsCaseDetails createCaseDetails() {

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreQuestionsPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreQuestionsPdfServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
@@ -28,7 +27,7 @@ public class StoreQuestionsPdfServiceTest {
         questionService = mock(QuestionService.class);
         onlineHearingId = "someOnlineHearingId";
         storeQuestionsPdfService = new StoreQuestionsPdfService(
-                mock(PdfService.class), "sometemplate", mock(SscsPdfService.class), mock(CcdService.class), mock(IdamService.class),
+                mock(PdfService.class), "sometemplate", mock(SscsPdfService.class), mock(IdamService.class),
                 questionService, mock(EvidenceManagementService.class));
     }
 


### PR DESCRIPTION
When we receive a COH event update CCD with the event. This then allows
the caseworker to see the progress for the COH case in CCD.

We will now need to send all event types through COR and then
pass on the ones with notifications to TYA-notifications.