### PR TITLE
Set COH thread pool to one

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/config/AsyncConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/config/AsyncConfiguration.java
@@ -19,10 +19,11 @@ public class AsyncConfiguration implements AsyncConfigurer {
     @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(2);
-        executor.setMaxPoolSize(4);
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("COHEventHandler-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.initialize();
         return executor;
     }


### PR DESCRIPTION
Have an issue where a request to issue question could still be being
processed when we get a request to issue a decision (not likely in
real life but happens in the tests). As they are now run in separate
threads the second request could have loaded the CCD data before the
first request has finished updating it. It then will update the CCD
itself but will wipe out the changes made by the first thread when
it saves them.

Change the ThreadPoolTaskExecutor to only have 1 thread. This is ok
as we want the Events endpoint to return to COH as quickly as
possible but don't really care that they are all processed one after
the other. In future a queuing mechanisem maybe better for this but
this is a quick fix whilst we have low numbers of appeals during
beta phase.