### PR TITLE
Tribunals view pdf no activities text

### DIFF
--- a/src/main/resources/templates/tribunalsView.html
+++ b/src/main/resources/templates/tribunalsView.html
@@ -141,44 +141,52 @@
         <div class="decision-activities">
             <div>
                 <div class="govuk-details__text">
-                    <h2 class="govuk-heading-m">Daily living activities and descriptors the tribunal considers to apply</h2>
-                    <table class="govuk-table">
-                        <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th class="govuk-table__header">Activity</th>
-                            <th class="govuk-table__header">Descriptor</th>
-                            <th class="govuk-table__header">Points</th>
-                        </tr>
-                        </thead>
-                        <tbody class="govuk-table__body">
-                            {% for activity in pdfSummary.decision.activities.daily_living %}
-                                <tr class="govuk-table__row">
-                                    <td class="govuk-table__cell">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].name }}</td>
-                                    <td class="govuk-table__cell">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].scores[activity.selection_key].text | raw }}</td>
-                                    <td class="govuk-table__cell">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].scores[activity.selection_key].score }}</td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                    <h2 class="govuk-heading-m">Mobility activities and descriptors the tribunal considers to apply</h2>
-                    <table class="govuk-table">
-                        <thead class="govuk-table__head">
-                        <tr class="govuk-table__row">
-                            <th class="govuk-table__header">Activity</th>
-                            <th class="govuk-table__header">Descriptor</th>
-                            <th class="govuk-table__header">Points</th>
-                        </tr>
-                        </thead>
-                        <tbody class="govuk-table__body">
-                            {% for activity in pdfSummary.decision.activities.mobility %}
-                                <tr class="govuk-table__row">
-                                    <td class="govuk-table__cell">{{ i18n.tribunalView.activities.mobility[activity.activity].name }}</td>
-                                    <td class="govuk-table__cell">{{ i18n.tribunalView.activities.mobility[activity.activity].scores[activity.selection_key].text | raw }}</td>
-                                    <td class="govuk-table__cell">{{ i18n.tribunalView.activities.mobility[activity.activity].scores[activity.selection_key].score }}</td>
-                                </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
+                    {% if pdfSummary.decision.activities.daily_living is not empty %}
+                        <h2 class="govuk-heading-m">Daily living activities and descriptors the tribunal considers to apply</h2>
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header">Activity</th>
+                                <th class="govuk-table__header">Descriptor</th>
+                                <th class="govuk-table__header">Points</th>
+                            </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                {% for activity in pdfSummary.decision.activities.daily_living %}
+                                    <tr class="govuk-table__row">
+                                        <td class="govuk-table__cell">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].name }}</td>
+                                        <td class="govuk-table__cell">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].scores[activity.selection_key].text | raw }}</td>
+                                        <td class="govuk-table__cell">{{ i18n.tribunalView.activities.dailyLiving[activity.activity].scores[activity.selection_key].score }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    {% else %}
+                        <h2 class="govuk-heading-m">The tribunal's view is that no daily living activities apply to your appeal</h2>
+                    {% endif %}
+                    {% if pdfSummary.decision.activities.mobility is not empty %}
+                        <h2 class="govuk-heading-m">Mobility activities and descriptors the tribunal considers to apply</h2>
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header">Activity</th>
+                                <th class="govuk-table__header">Descriptor</th>
+                                <th class="govuk-table__header">Points</th>
+                            </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                {% for activity in pdfSummary.decision.activities.mobility %}
+                                    <tr class="govuk-table__row">
+                                        <td class="govuk-table__cell">{{ i18n.tribunalView.activities.mobility[activity.activity].name }}</td>
+                                        <td class="govuk-table__cell">{{ i18n.tribunalView.activities.mobility[activity.activity].scores[activity.selection_key].text | raw }}</td>
+                                        <td class="govuk-table__cell">{{ i18n.tribunalView.activities.mobility[activity.activity].scores[activity.selection_key].score }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    {% else %}
+                        <h2 class="govuk-heading-m">The tribunal's view is that no mobility activities apply to your appeal</h2>
+                    {% endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
If you don't have either daily living or mobility activities in the
decision then the table header was being added to the pdf but there
were no rows. In the frontend we display some text saying the panel
did not take this in to account. Updated the pdf to reflect how the
frontend will display this.