### PR TITLE
Sscs 5072 email dwp deadline expires 2

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CreateHearingPdfTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CreateHearingPdfTest.java
@@ -21,6 +21,12 @@ public class CreateHearingPdfTest extends BaseFunctionTest {
         answerQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());
         createAndIssueDecision(onlineHearing.getHearingId(), onlineHearing.getCaseId());
 
+        // Dirty fix for now. As we create the hearing with COH on AAT it calls back to COR on AAT. Therefore it can be
+        // adding events to the case as we call the decision issued. This can then fail in CCD with a
+        // uk.gov.hmcts.ccd.endpoint.exceptions.CaseConcurrencyException. Need to think about a better way to handle
+        // this.
+        Thread.sleep(10000L);
+
         decisionIssued(onlineHearing.getHearingId(), onlineHearing.getCaseId());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/AnswerSubmittedEventAction.java
@@ -2,41 +2,19 @@ package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.StoreAnswersPdfService;
-import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 @Service
-public class AnswerSubmittedEventAction implements CohEventAction {
-    private final CorEmailService corEmailService;
-    private final StorePdfService storeAnswersPdfService;
-    private final DwpEmailMessageBuilder dwpEmailMessageBuilder;
+public class AnswerSubmittedEventAction extends QuestionRoundEndedAction {
 
     public AnswerSubmittedEventAction(CorEmailService corEmailService, StoreAnswersPdfService storeAnswersPdfService, DwpEmailMessageBuilder dwpEmailMessageBuilder) {
-        this.corEmailService = corEmailService;
-        this.storeAnswersPdfService = storeAnswersPdfService;
-        this.dwpEmailMessageBuilder = dwpEmailMessageBuilder;
+        super(storeAnswersPdfService, corEmailService, dwpEmailMessageBuilder);
     }
 
-    @Override
-    public CohEventActionContext createAndStorePdf(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
-        return storeAnswersPdfService.storePdf(caseId, onlineHearingId, caseDetails);
-    }
-
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        SscsCaseDetails sscsCaseDetails = cohEventActionContext.getDocument();
-        String caseReference = sscsCaseDetails.getData().getCaseReference();
-        corEmailService.sendPdfToDwp(
-                cohEventActionContext,
-                "Appellant has provided information (" + caseReference + ")",
-                dwpEmailMessageBuilder.getAnswerMessage(sscsCaseDetails)
-        );
-
-        return cohEventActionContext;
+    protected String getDwpEmailSubject(String caseReference) {
+        return "Appellant has provided information (" + caseReference + ")";
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineElapsedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineElapsedEventAction.java
@@ -1,19 +1,31 @@
 package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
+import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
+import uk.gov.hmcts.reform.sscscorbackend.service.StoreAnswersDeadlineElapsedPdfService;
 
 @Service
-public class DeadlineElapsedEventAction implements CohEventAction {
-    @Override
-    public String cohEvent() {
-        return "question_deadline_elapsed";
+public class DeadlineElapsedEventAction extends QuestionRoundEndedAction {
+
+    @Autowired
+    public DeadlineElapsedEventAction(
+            CorEmailService corEmailService,
+            StoreAnswersDeadlineElapsedPdfService storeQuestionsPdfService,
+            DwpEmailMessageBuilder dwpEmailMessageBuilder) {
+        super(storeQuestionsPdfService, corEmailService, dwpEmailMessageBuilder);
     }
 
     @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        return cohEventActionContext;
+    protected String getDwpEmailSubject(String caseReference) {
+        return "Appellant has provided information (" + caseReference + ")";
+    }
+
+    @Override
+    public String cohEvent() {
+        return "question_deadline_elapsed";
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundEndedAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/QuestionRoundEndedAction.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
+import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
+import uk.gov.hmcts.reform.sscscorbackend.service.StorePdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+public abstract class QuestionRoundEndedAction implements CohEventAction {
+    protected final StorePdfService storePdfService;
+    protected final CorEmailService corEmailService;
+    protected final DwpEmailMessageBuilder dwpEmailMessageBuilder;
+
+    public QuestionRoundEndedAction(StorePdfService storeQuestionsPdfService, CorEmailService corEmailService, DwpEmailMessageBuilder dwpEmailMessageBuilder) {
+        this.storePdfService = storeQuestionsPdfService;
+        this.corEmailService = corEmailService;
+        this.dwpEmailMessageBuilder = dwpEmailMessageBuilder;
+    }
+
+    @Override
+    public CohEventActionContext createAndStorePdf(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
+        return storePdfService.storePdf(caseId, onlineHearingId, caseDetails);
+    }
+
+    @Override
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
+        SscsCaseDetails sscsCaseDetails = cohEventActionContext.getDocument();
+        String caseReference = sscsCaseDetails.getData().getCaseReference();
+        corEmailService.sendPdfToDwp(
+                cohEventActionContext,
+                getDwpEmailSubject(caseReference),
+                dwpEmailMessageBuilder.getAnswerMessage(sscsCaseDetails)
+        );
+
+        return cohEventActionContext;
+    }
+
+    protected abstract String getDwpEmailSubject(String caseReference);
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersDeadlineElapsedPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersDeadlineElapsedPdfService.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
+import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+
+@Service
+@SuppressWarnings("common-java:DuplicatedBlocks")
+public class StoreAnswersDeadlineElapsedPdfService extends AbstractQuestionPdfService {
+
+    @SuppressWarnings("squid:S00107")
+    public StoreAnswersDeadlineElapsedPdfService(
+            PdfService pdfService,
+            @Value("${answer.html.template.path}") String templatePath,
+            SscsPdfService sscsPdfService,
+            IdamService idamService,
+            QuestionService questionService,
+            EvidenceManagementService evidenceManagementService) {
+        super(pdfService, templatePath, sscsPdfService, idamService, questionService, evidenceManagementService);
+    }
+
+    @Override
+    String documentNamePrefix() {
+        return "Issued Answers Deadline Elapsed Round ";
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineElapsedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/coheventmapper/DeadlineElapsedEventActionTest.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.sscscorbackend.controllers.coheventmapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscscorbackend.service.CorEmailService;
+import uk.gov.hmcts.reform.sscscorbackend.service.DwpEmailMessageBuilder;
+import uk.gov.hmcts.reform.sscscorbackend.service.StoreAnswersDeadlineElapsedPdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.Pdf;
+
+public class DeadlineElapsedEventActionTest {
+    @Test
+    public void canSendPdf() {
+        CorEmailService corEmailService = mock(CorEmailService.class);
+        StoreAnswersDeadlineElapsedPdfService storeAnswersPdfService = mock(StoreAnswersDeadlineElapsedPdfService.class);
+        DwpEmailMessageBuilder dwpEmailMessageBuilder = mock(DwpEmailMessageBuilder.class);
+
+        DeadlineElapsedEventAction deadlineElapsedEventAction = new DeadlineElapsedEventAction(corEmailService, storeAnswersPdfService, dwpEmailMessageBuilder);
+
+        String someCaseReference = "someCaseReference";
+        SscsCaseDetails caseDetails = SscsCaseDetails.builder()
+                .data(SscsCaseData.builder().caseReference(someCaseReference).build())
+                .build();
+        long caseId = 123L;
+        String onlineHearingId = "onlineHearingId";
+        String pdfName = "pdf_name.pdf";
+        CohEventActionContext cohEventActionContext = new CohEventActionContext(new Pdf(new byte[]{2, 5, 6, 0, 1}, pdfName), caseDetails);
+        when(dwpEmailMessageBuilder.getAnswerMessage(caseDetails)).thenReturn("some message");
+
+        CohEventActionContext result = deadlineElapsedEventAction.handle(caseId, onlineHearingId, cohEventActionContext);
+
+        verify(corEmailService).sendPdfToDwp(cohEventActionContext, "Appellant has provided information (" + someCaseReference + ")", "some message");
+        assertThat(result, is(cohEventActionContext));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersDeadlineElapsedPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersDeadlineElapsedPdfServiceTest.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
+import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
+import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
+import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+
+public class StoreAnswersDeadlineElapsedPdfServiceTest {
+
+    private QuestionService questionService;
+    private String onlineHearingId;
+    private StoreAnswersDeadlineElapsedPdfService storeQuestionsPdfService;
+
+    @Before
+    public void setUp() {
+        questionService = mock(QuestionService.class);
+        onlineHearingId = "someOnlineHearingId";
+        storeQuestionsPdfService = new StoreAnswersDeadlineElapsedPdfService(
+                mock(PdfService.class), "sometemplate", mock(SscsPdfService.class), mock(IdamService.class),
+                questionService, mock(EvidenceManagementService.class));
+    }
+
+    @Test
+    public void getPdfQuestionSummary() {
+        QuestionRound questionRound = DataFixtures.someQuestionRound();
+        when(questionService.getQuestions(onlineHearingId)).thenReturn(questionRound);
+        PdfAppealDetails appealDetails = mock(PdfAppealDetails.class);
+        PdfQuestionsSummary pdfQuestionsSummary = storeQuestionsPdfService.getPdfContent(mock(SscsCaseDetails.class), onlineHearingId, appealDetails);
+
+        assertThat(pdfQuestionsSummary, is(new PdfQuestionsSummary(appealDetails, questionRound.getQuestions())));
+    }
+
+    @Test
+    public void getPdfQuestionRound() {
+        when(questionService.getCurrentQuestionRound(onlineHearingId)).thenReturn(66);
+        String documentNamePrefix = storeQuestionsPdfService.documentNamePrefix(mock(SscsCaseDetails.class), onlineHearingId);
+
+        assertThat(documentNamePrefix, is("Issued Answers Deadline Elapsed Round 66 - "));
+    }
+}


### PR DESCRIPTION
When the deadline for a round of questions expires and the appellant has
not submitted all the answers send DWP and email containing a PDF of the
submitted answers. PDF must not contain draft answers. This is a
combination of the logic when the answers are submitted and our old way
of handling deadline expired as we also need to notify the appellant.