### PR TITLE
SSCS-5230 Display final decision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ dependencies {
   compileOnly 'org.projectlombok:lombok:1.18.6'
   compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.2.4.RELEASE'
   compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.5.0'
-  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.141'
+  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.142'
 
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.105'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '4.0.2'

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohEventsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohEventsTest.java
@@ -36,6 +36,7 @@ public class CohEventsTest extends BaseIntegrationTest {
         ccdStub.stubFindCaseByCaseId(caseId, caseReference, "first-id", "someEvidence", "evidenceCreatedDate", "http://example.com/document/1");
         ccdStub.stubUpdateCase(caseId);
         ccdStub.stubUpdateCaseWithEvent(caseId, EventType.COH_DECISION_ISSUED.getCcdType());
+        ccdStub.stubGetHistoryEvents(caseId, EventType.SYA_APPEAL_CREATED);
         String cohEvent = createCohEvent("decision_issued");
         notificationsStub.stubSendNotification(cohEvent);
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/OnlineHearingTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/OnlineHearingTest.java
@@ -8,6 +8,7 @@ import io.restassured.RestAssured;
 import java.io.UnsupportedEncodingException;
 import org.junit.Test;
 import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 
 public class OnlineHearingTest extends BaseIntegrationTest {
 
@@ -21,6 +22,7 @@ public class OnlineHearingTest extends BaseIntegrationTest {
     @Test
     public void getsOnlineHearing() throws UnsupportedEncodingException, JsonProcessingException {
         ccdStub.stubSearchCaseWithEmailAddress(email, caseId, expectedCaseReference, firstName, lastName);
+        ccdStub.stubGetHistoryEvents(caseId, EventType.FINAL_DECISION);
         cohStub.stubGetOnlineHearing(caseId, expectedOnlineHearingId);
         cohStub.stubGetDecisionNotFound(expectedOnlineHearingId);
         cohStub.stubGetDecisionRepliesNotFound(expectedOnlineHearingId);
@@ -40,6 +42,7 @@ public class OnlineHearingTest extends BaseIntegrationTest {
     @Test
     public void getsOnlineHearingWithDecision() throws UnsupportedEncodingException, JsonProcessingException {
         ccdStub.stubSearchCaseWithEmailAddress(email, caseId, expectedCaseReference, firstName, lastName);
+        ccdStub.stubGetHistoryEvents(caseId, EventType.FINAL_DECISION);
         cohStub.stubGetOnlineHearing(caseId, expectedOnlineHearingId);
         cohStub.stubGetDecisions(expectedOnlineHearingId, caseId);
         cohStub.stubGetDecisionRepliesEmpty(expectedOnlineHearingId);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
@@ -8,8 +8,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 
 public class CcdStub extends BaseStub {
 
@@ -119,6 +122,15 @@ public class CcdStub extends BaseStub {
     public void stubRemoveUserFromCase(long caseId, String userToRemove) throws JsonProcessingException {
         wireMock.stubFor(delete("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/users/" + userToRemove)
                 .willReturn(created()));
+    }
+
+    public void stubGetHistoryEvents(Long caseId, EventType... eventTypes) {
+        String responseJson = Arrays.stream(eventTypes)
+                .map(event -> "{\"id\":\"" + event.getCcdType() + "\"}")
+                .collect(Collectors.joining(",", "[", "]"));
+        wireMock.stubFor(get("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/events")
+                .willReturn(okJson(responseJson))
+        );
     }
 
     private String createCaseDetails(Long caseId, String caseReference, String firstName, String lastName, String evidenceQuestionId, String evidenceFileName, String evidenceCreatedDate, String evidenceUrl) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/OnlineHearing.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/OnlineHearing.java
@@ -13,13 +13,15 @@ public class OnlineHearing {
     private String caseReference;
     private Decision decision;
     private FinalDecision finalDecision;
+    private boolean hasFinalDecision;
 
-    public OnlineHearing(String onlineHearingId, String appellantName, String caseReference, Decision decision, FinalDecision finalDecision) {
+    public OnlineHearing(String onlineHearingId, String appellantName, String caseReference, Decision decision, FinalDecision finalDecision, boolean hasFinalDecision) {
         this.onlineHearingId = onlineHearingId;
         this.appellantName = appellantName;
         this.caseReference = caseReference;
         this.decision = decision;
         this.finalDecision = finalDecision;
+        this.hasFinalDecision = hasFinalDecision;
     }
 
     @ApiModelProperty(example = "ID_1", required = true)
@@ -48,5 +50,10 @@ public class OnlineHearing {
     @JsonProperty(value = "final_decision")
     public FinalDecision getFinalDecision() {
         return finalDecision;
+    }
+
+    @JsonProperty(value = "has_final_decision")
+    public boolean isHasFinalDecision() {
+        return hasFinalDecision;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingDateReformatter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingDateReformatter.java
@@ -32,7 +32,8 @@ public class OnlineHearingDateReformatter {
                 onlineHearing.getAppellantName(),
                 onlineHearing.getCaseReference(),
                 newDecision,
-                onlineHearing.getFinalDecision());
+                onlineHearing.getFinalDecision(),
+                onlineHearing.isHasFinalDecision());
     }
 
     private String reformatDate(String dateString) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/CcdClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/CcdClient.java
@@ -1,11 +1,15 @@
 package uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi.SERVICE_AUTHORIZATION;
 
+import java.util.List;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api.CcdAddUser;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api.CcdHistoryEvent;
 
 @FeignClient(
         name = "Ccd",
@@ -32,5 +36,18 @@ public interface CcdClient {
             @PathVariable("caseType") String caseType,
             @PathVariable("caseId") long caseId,
             @PathVariable("idToDelete") String idToDelete
+    );
+
+    @GetMapping(
+            value = "/caseworkers/{userId}/jurisdictions/{jurisdictionId}/case-types/{caseType}/cases/{caseId}/events",
+            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+    )
+    List<CcdHistoryEvent> getHistoryEvents(
+            @RequestHeader(AUTHORIZATION) String authorisation,
+            @RequestHeader(SERVICE_AUTHORIZATION) String serviceAuthorisation,
+            @PathVariable("userId") String userId,
+            @PathVariable("jurisdictionId") String jurisdictionId,
+            @PathVariable("caseType") String caseType,
+            @PathVariable("caseId") long caseId
     );
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/CorCcdService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/CorCcdService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd;
 
+import java.util.List;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.config.CcdRequestDetails;
 import uk.gov.hmcts.reform.sscs.ccd.service.CreateCcdCaseService;
@@ -9,6 +10,7 @@ import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api.CcdAddUser;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api.CcdHistoryEvent;
 
 @Service
 public class CorCcdService extends uk.gov.hmcts.reform.sscs.ccd.service.CcdService {
@@ -53,6 +55,18 @@ public class CorCcdService extends uk.gov.hmcts.reform.sscs.ccd.service.CcdServi
                 ccdRequestDetails.getCaseTypeId(),
                 caseId,
                 userIdToRemove
+        );
+    }
+
+    public List<CcdHistoryEvent> getHistoryEvents(long caseId) {
+        IdamTokens idamTokens = idamService.getIdamTokens();
+        return ccdClient.getHistoryEvents(
+                idamTokens.getIdamOauth2Token(),
+                idamTokens.getServiceAuthorization(),
+                idamTokens.getUserId(),
+                ccdRequestDetails.getJurisdictionId(),
+                ccdRequestDetails.getCaseTypeId(),
+                caseId
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/api/CcdHistoryEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/api/CcdHistoryEvent.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+
+public class CcdHistoryEvent {
+    private final String id;
+
+    public CcdHistoryEvent(@JsonProperty(value = "id")String id) {
+        this.id = id;
+    }
+
+    public EventType getEventType() {
+        return EventType.getEventTypeByCcdType(id);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -113,17 +113,17 @@ public class DataFixtures {
     }
 
     public static OnlineHearing someOnlineHearing() {
-        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", null, new FinalDecision("final decision"));
+        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", null, new FinalDecision("final decision"), true);
     }
 
     public static OnlineHearing someOnlineHearingWithDecision() {
         Decision decision = new Decision("decision_issued", now().format(ISO_LOCAL_DATE_TIME), null, null, "startDate", "endDate", null, "decisionReason", null);
-        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", decision, new FinalDecision("final decision"));
+        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", decision, new FinalDecision("final decision"), true);
     }
 
     public static OnlineHearing someOnlineHearingWithDecisionAndAppellentReply() {
         Decision decision = new Decision("decision_issued", now().format(ISO_LOCAL_DATE_TIME), "decision_accepted", now().format(ISO_LOCAL_DATE_TIME), "startDate", "endDate", null, "decisionReason", null);
-        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", decision, new FinalDecision("final decision"));
+        return new OnlineHearing("someOnlineHearingId", "someAppellantName", "someCaseReference", decision, new FinalDecision("final decision"), true);
     }
 
     public static Evidence someEvidence() {

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.*;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.Before;
@@ -19,6 +20,7 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.Decision;
 import uk.gov.hmcts.reform.sscscorbackend.domain.OnlineHearing;
 import uk.gov.hmcts.reform.sscscorbackend.domain.TribunalViewResponse;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api.CcdHistoryEvent;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.apinotifications.CaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.apinotifications.CcdEvent;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.CohService;
@@ -215,10 +217,12 @@ public class OnlineHearingServiceTest {
         SscsCaseDetails sscsCaseDetails = createCaseDetails(someCaseId, "caseref", "firstname", "lastname", "online");
 
         when(cohService.getOnlineHearing(someCaseId)).thenReturn(DataFixtures.someCohOnlineHearings());
+        when(ccdService.getHistoryEvents(someCaseId)).thenReturn(singletonList(new CcdHistoryEvent(EventType.FINAL_DECISION.getCcdType())));
         Optional<OnlineHearing> onlineHearing = underTest.loadOnlineHearingFromCoh(sscsCaseDetails);
 
         assertThat(onlineHearing.isPresent(), is(true));
         assertThat(onlineHearing.get().getFinalDecision().getReason(), is(sscsCaseDetails.getData().getDecisionNotes()));
+        assertThat(onlineHearing.get().isHasFinalDecision(), is(true));
     }
 
     @Test
@@ -268,6 +272,7 @@ public class OnlineHearingServiceTest {
                                 ).build()
                         )
                         .decisionNotes("decision notes")
+                        .events(new ArrayList<>())
                         .build()
                 ).build();
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/CorCcdServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/CorCcdServiceTest.java
@@ -1,7 +1,11 @@
 package uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.config.CcdRequestDetails;
@@ -12,6 +16,7 @@ import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api.CcdAddUser;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api.CcdHistoryEvent;
 
 public class CorCcdServiceTest {
 
@@ -84,4 +89,18 @@ public class CorCcdServiceTest {
                 userToRemove);
     }
 
+    @Test
+    public void canGetHistoryEvents() {
+        List<CcdHistoryEvent> historyEvents = asList(new CcdHistoryEvent("id"));
+        when(ccdClient.getHistoryEvents(authToken,
+                serviceAuthToken,
+                userId,
+                jurisdictionId,
+                caseTypeId,
+                caseId)).thenReturn(historyEvents);
+
+        List<CcdHistoryEvent> actualHistoryEvents = corCcdService.getHistoryEvents(caseId);
+
+        assertThat(actualHistoryEvents, is(historyEvents));
+    }
 }


### PR DESCRIPTION
In the frontend we were working out if there was a final decision based
on the state of the COH decision. But this does not reflect final
decisions only tribunal views. Therefore we need to look in the CCD
events to see if a final decision has been issued. We now return an
extra boolean value in the api has_final_decision. That the frontend can
use to display a final decision.