### PR TITLE
SSCS-5230 View final decision when there is no Preliminary View

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/coh/DecisionExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/coh/DecisionExtractor.java
@@ -47,6 +47,12 @@ public class DecisionExtractor {
         JSONObject jsonObject = new JSONObject(decision.getDecisionText());
         JSONObject decisionJson = jsonObject.getJSONObject("decisions_SSCS_benefit_" + caseId);
 
+        String isPreliminaryView = decisionJson.getString("preliminaryView");
+
+        if (!"yes".equals(isPreliminaryView)) {
+            return null;
+        }
+
         String startDateString = getDate(decisionJson, "Start");
 
         String endDateRadio = decisionJson.getString("endDateRadio");

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/coh/DecisionExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/coh/DecisionExtractorTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -89,6 +90,17 @@ public class DecisionExtractorTest {
             "      \"awardStartDateYear\":\"2017\"\n" +
             "   }\n" +
             "}";
+    private final String finalDecision = "{\n" +
+            "\"decisions_SSCS_benefit_1234321\": {\n" +
+            "\"preliminaryView\": \"no\",\n" +
+            "\"visitedPages\": {\n" +
+            "\"create\": true,\n" +
+            "\"final-decision\": true\n" +
+            "},\n" +
+            "\"decisionNotes\": \"s simply dummy text\"\n" +
+            "}\n" +
+            "}";
+
     private final String decisionsState = "decisionsState";
     private final String decisionsStartDateTime = "decisionsStartDateTime";
     private final String appellantReply = "appellantReply";
@@ -143,5 +155,16 @@ public class DecisionExtractorTest {
                         asList(new Activity("planningFollowingJourneys", "12"))
                 ))
         ));
+    }
+
+    @Test
+    public void canHandleFinalDecisionJson() {
+        CohDecision cohDecision = new CohDecision(
+                "onlineHearingId", "", "", "", finalDecision, new CohState(decisionsState, decisionsStartDateTime)
+        );
+
+        Decision decision = new DecisionExtractor().extract(caseId, cohDecision, cohDecisionReply);
+
+        assertThat(decision, is(nullValue()));
     }
 }


### PR DESCRIPTION
In JUI the panel can issue a final decision without issuing a
preliminary view. COR could not handle this as it tries to parse
it as a Preliminary view and some of the data is not there. Update
parsing when there is no PV.