### PR TITLE
Check activities and score are mapped

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/ActivitiesValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/ActivitiesValidator.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscscorbackend.domain.Activities;
+import uk.gov.hmcts.reform.sscscorbackend.domain.Activity;
+import uk.gov.hmcts.reform.sscscorbackend.domain.OnlineHearing;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.I18nBuilder;
+
+@Component
+public class ActivitiesValidator {
+    private final Map i18n;
+
+    public ActivitiesValidator(I18nBuilder i18nBuilder) throws IOException {
+        this.i18n = i18nBuilder.build();
+    }
+
+    public void validateWeHaveMappingForActivities(OnlineHearing onlineHearing) {
+        Activities activities = onlineHearing.getDecision().getActivities();
+        Map activitiesMap = (Map) (((Map) i18n.get("tribunalView")).get("activities"));
+        validate(activities.getDailyLiving(), (Map)(activitiesMap.get("dailyLiving")));
+        validate(activities.getMobility(), (Map)(activitiesMap.get("mobility")));
+    }
+
+    private void validate(List<Activity> dailyLiving, Map activitiesMap) {
+        dailyLiving.forEach(activity -> {
+            Map activityMap = (Map)(activitiesMap.get(activity.getActivity()));
+            if (activityMap == null) {
+                throw new IllegalArgumentException("Cannot find mapping for activity [" + activity.getActivity() + "]");
+            }
+            Object score = ((Map)activityMap.get("scores")).get(activity.getSelectionKey());
+            if (score == null) {
+                throw new IllegalArgumentException("Cannot find score for activity [" + activity.getActivity() + "] and key [" + activity.getSelectionKey() + "]");
+            }
+        });
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewService.java
@@ -19,6 +19,7 @@ public class StoreOnlineHearingTribunalsViewService extends StorePdfService<Onli
     public static final String TRIBUNALS_VIEW_PDF_PREFIX = "Tribunals view - ";
     private final OnlineHearingService onlineHearingService;
     private final OnlineHearingDateReformatter onlineHearingDateReformatter;
+    private final ActivitiesValidator activitiesValidator;
 
     @SuppressWarnings("squid:S00107")
     public StoreOnlineHearingTribunalsViewService(OnlineHearingService onlineHearingService,
@@ -26,10 +27,12 @@ public class StoreOnlineHearingTribunalsViewService extends StorePdfService<Onli
                                                   @Value("${preliminary_view.html.template.path}") String templatePath,
                                                   OnlineHearingDateReformatter onlineHearingDateReformatter,
                                                   SscsPdfService sscsPdfService, IdamService idamService,
-                                                  EvidenceManagementService evidenceManagementService) {
+                                                  EvidenceManagementService evidenceManagementService,
+                                                  ActivitiesValidator activitiesValidator) {
         super(pdfService, templatePath, sscsPdfService, idamService, evidenceManagementService);
         this.onlineHearingService = onlineHearingService;
         this.onlineHearingDateReformatter = onlineHearingDateReformatter;
+        this.activitiesValidator = activitiesValidator;
     }
 
     @Override
@@ -41,6 +44,8 @@ public class StoreOnlineHearingTribunalsViewService extends StorePdfService<Onli
     protected OnlineHearing getPdfContent(SscsCaseDetails caseDetails, String onlineHearingId, PdfAppealDetails appealDetails) {
         Optional<OnlineHearing> optionalOnlineHearing = onlineHearingService.loadOnlineHearingFromCoh(caseDetails);
         OnlineHearing onlineHearing = optionalOnlineHearing.orElseThrow(() -> new IllegalArgumentException("Cannot find online hearing for case id [" + caseDetails.getId() + "]"));
+
+        activitiesValidator.validateWeHaveMappingForActivities(onlineHearing);
 
         return onlineHearingDateReformatter.getReformattedOnlineHearing(onlineHearing);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/ActivitiesValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/ActivitiesValidatorTest.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscscorbackend.domain.*;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.I18nBuilder;
+
+public class ActivitiesValidatorTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void failsIfDailyLivingActivityNotMapped() throws IOException {
+
+        I18nBuilder i18nBuilder = new I18nBuilder();
+
+        OnlineHearing onlineHearing = createOnlineHearing(new Activity("notMappedActivity", "1"), new Activity("movingAround", "0"));
+        new ActivitiesValidator(i18nBuilder).validateWeHaveMappingForActivities(onlineHearing);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsIfMobilityActivityNotMapped() throws IOException {
+
+        I18nBuilder i18nBuilder = new I18nBuilder();
+
+        OnlineHearing onlineHearing = createOnlineHearing(new Activity("makingBudgetingDecisions", "6"), new Activity("notMappedActivity", "0"));
+        new ActivitiesValidator(i18nBuilder).validateWeHaveMappingForActivities(onlineHearing);
+    }
+
+    @Test
+    public void passesIfAllActivitiesAndScoresMapped() throws IOException {
+        I18nBuilder i18nBuilder = new I18nBuilder();
+
+        OnlineHearing onlineHearing = createOnlineHearing(new Activity("makingBudgetingDecisions", "6"), new Activity("movingAround", "0"));
+        new ActivitiesValidator(i18nBuilder).validateWeHaveMappingForActivities(onlineHearing);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsIfDailyLivingActivityScoreNotMapped() throws IOException {
+
+        I18nBuilder i18nBuilder = new I18nBuilder();
+
+        OnlineHearing onlineHearing = createOnlineHearing(new Activity("makingBudgetingDecisions", "999"), new Activity("movingAround", "0"));
+        new ActivitiesValidator(i18nBuilder).validateWeHaveMappingForActivities(onlineHearing);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsIfMobilityActivityScoreNotMapped() throws IOException {
+
+        I18nBuilder i18nBuilder = new I18nBuilder();
+
+        OnlineHearing onlineHearing = createOnlineHearing(new Activity("makingBudgetingDecisions", "6"), new Activity("movingAround", "999"));
+        new ActivitiesValidator(i18nBuilder).validateWeHaveMappingForActivities(onlineHearing);
+    }
+
+    private OnlineHearing createOnlineHearing(Activity dailyLiving, Activity mobility) {
+        return new OnlineHearing(
+                "hearingId",
+                "appellantName",
+                "caseRef",
+                new Decision(
+                        "sate",
+                        "startTime",
+                        "appellantReply",
+                        "replyDate",
+                        "startDate",
+                        "endDate",
+                        mock(DecisionRates.class),
+                        "reason",
+                        new Activities(singletonList(dailyLiving), singletonList(mobility))
+                ),
+                new FinalDecision("reason"),
+                true
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewServiceTest.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
+import java.io.IOException;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,6 +11,8 @@ import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscs.service.SscsPdfService;
+import uk.gov.hmcts.reform.sscscorbackend.domain.OnlineHearing;
+import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 public class StoreOnlineHearingTribunalsViewServiceTest {
@@ -26,9 +28,10 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
     private SscsCaseDetails sscsCaseDetails;
     private SscsCaseData sscsCaseData;
     private String someHearingId;
+    private ActivitiesValidator activitiesValidator;
 
     @Before
-    public void setUp() {
+    public void setUp() throws IOException {
         onlineHearingService = mock(OnlineHearingService.class);
         onlineHearingDateReformatter = mock(OnlineHearingDateReformatter.class);
         pdfService = mock(PdfService.class);
@@ -37,6 +40,7 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
         IdamService idamService = mock(IdamService.class);
         idamTokens = mock(IdamTokens.class);
         when(idamService.getIdamTokens()).thenReturn(idamTokens);
+        activitiesValidator = mock(ActivitiesValidator.class);
         storeOnlineHearingTribunalsViewService = new StoreOnlineHearingTribunalsViewService(
                 onlineHearingService,
                 pdfService,
@@ -44,7 +48,8 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
                 onlineHearingDateReformatter,
                 sscsPdfService,
                 idamService,
-                mock(EvidenceManagementService.class));
+                mock(EvidenceManagementService.class),
+                activitiesValidator);
         someHearingId = "someHearingId";
     }
 
@@ -55,6 +60,17 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
 
         when(onlineHearingService.loadOnlineHearingFromCoh(sscsCaseDetails)).thenReturn(Optional.empty());
         storeOnlineHearingTribunalsViewService.storePdf(someCaseId, someHearingId, sscsCaseDetails);
+    }
+
+    @Test
+    public void getPdfContentVerifiesContent() {
+        SscsCaseDetails caseDetails = mock(SscsCaseDetails.class);
+        OnlineHearing onlineHearing = mock(OnlineHearing.class);
+        when(onlineHearingService.loadOnlineHearingFromCoh(caseDetails)).thenReturn(Optional.of(onlineHearing));
+
+        storeOnlineHearingTribunalsViewService.getPdfContent(caseDetails, "hearingId", mock(PdfAppealDetails.class));
+
+        verify(activitiesValidator).validateWeHaveMappingForActivities(onlineHearing);
     }
 
     private SscsCaseData createSscsCaseData() {


### PR DESCRIPTION
We a tribunal view is issued we generate a PDF with the details in it.
If we send an activity or score to the PDF service without a mapped
value to display the PDF service fails with a very generic error. Added
in checking that that we have mapped values in en.json for all
activities and scores as we pass them to the PDF service.