### PR TITLE
Use isCorDecision field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ dependencies {
   compileOnly 'org.projectlombok:lombok:1.18.6'
   compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.2.4.RELEASE'
   compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.7.0'
-  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.152'
+  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.153'
 
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.112'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '4.0.2'

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
@@ -170,9 +169,8 @@ public class OnlineHearingService {
                 .map(onlineHearing -> {
                     Name name = sscsCaseDeails.getData().getAppeal().getAppellant().getName();
                     String nameString = name.getFirstName() + " " + name.getLastName();
-
-                    boolean hasFinalDecision = historyEvents.stream()
-                                    .anyMatch(event -> EventType.FINAL_DECISION == event.getEventType());
+                    
+                    boolean hasFinalDecision = sscsCaseDeails.getData().isCorDecision();
 
                     return new OnlineHearing(
                             onlineHearing.getOnlineHearingId(),

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
@@ -249,6 +249,7 @@ public class OnlineHearingServiceTest {
     @Test
     public void loadOnlineHearingIncludsFinalDecision() {
         SscsCaseDetails sscsCaseDetails = createCaseDetails(someCaseId, "caseref", "firstname", "lastname", "online");
+        sscsCaseDetails.getData().setIsCorDecision("YES");
 
         when(cohService.getOnlineHearing(someCaseId)).thenReturn(DataFixtures.someCohOnlineHearings());
         when(ccdService.getHistoryEvents(someCaseId)).thenReturn(singletonList(new CcdHistoryEvent(EventType.FINAL_DECISION.getCcdType())));


### PR DESCRIPTION
Rather than decision event to decide if the case has a decision. 
This is set by JUI and will work for now as the CCD endpoint to 
get events is not working since the IDAM switch over.