### PR TITLE
Use isCorDecision field rather than decision event to decide if the

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,7 @@ dependencies {
   compileOnly 'org.projectlombok:lombok:1.18.6'
   compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.2.4.RELEASE'
   compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.7.0'
-  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.153'
+  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '0.0.154'
 
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.112'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '4.0.2'

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CreateHearingPdfTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CreateHearingPdfTest.java
@@ -15,7 +15,7 @@ public class CreateHearingPdfTest extends BaseFunctionTest {
         relistHearing(onlineHearing.getHearingId(), onlineHearing.getCaseId());
     }
 
-    //@Test
+    @Test
     public void recordRejectedResponse() throws IOException, InterruptedException {
         OnlineHearing onlineHearing = createHearingWithQuestion(true);
         answerQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAnOnlineHearingTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/GetAnOnlineHearingTest.java
@@ -12,11 +12,6 @@ import org.junit.Test;
 public class GetAnOnlineHearingTest extends BaseFunctionTest {
 
     @Test
-    public void defaultTest() throws IOException, InterruptedException {
-        System.out.println("Test");
-    }
-
-    //@Test
     public void getAnOnlineHearing() throws IOException, InterruptedException {
         OnlineHearing onlineHearing = createHearingWithQuestion(true);
 
@@ -28,7 +23,7 @@ public class GetAnOnlineHearingTest extends BaseFunctionTest {
         assertThat(decision, is(nullValue()));
     }
 
-    //@Test
+    @Test
     public void getAnOnlineHearingWithDecision() throws IOException, InterruptedException {
         OnlineHearing onlineHearing = createHearingWithQuestion(true);
         answerQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());
@@ -45,7 +40,7 @@ public class GetAnOnlineHearingTest extends BaseFunctionTest {
         assertThat(decision.has("appellant_reply_datetime"), is(false));
     }
 
-    //@Test
+    @Test
     public void getAnOnlineHearingWithDecisionAndAppellantReplyAccepted() throws IOException, InterruptedException {
         OnlineHearing onlineHearing = createHearingWithQuestion(true);
         answerQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/MailStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/MailStub.java
@@ -73,4 +73,12 @@ public class MailStub {
         List<SmtpMessage> receivedEmails = smtpServer.getReceivedEmails();
         assertThat(receivedEmails, is(empty()));
     }
+
+    public static void main(String[] args) throws IOException, InterruptedException {
+        new MailStub(1025);
+
+        while (true) {
+            Thread.sleep(50000L);
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.FinalDecision;
 import uk.gov.hmcts.reform.sscscorbackend.domain.OnlineHearing;
 import uk.gov.hmcts.reform.sscscorbackend.domain.TribunalViewResponse;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api.CcdHistoryEvent;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.apinotifications.CaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.apinotifications.CcdEvent;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.CohService;
@@ -162,7 +161,6 @@ public class OnlineHearingService {
 
     public Optional<OnlineHearing> loadOnlineHearingFromCoh(SscsCaseDetails sscsCaseDeails) {
         CohOnlineHearings cohOnlineHearings = cohClient.getOnlineHearing(sscsCaseDeails.getId());
-        List<CcdHistoryEvent> historyEvents = ccdService.getHistoryEvents(sscsCaseDeails.getId());
 
         return cohOnlineHearings.getOnlineHearings().stream()
                 .findFirst()


### PR DESCRIPTION
case has a decision. This is set by JUI and will work for now as the
CCD endpoint to get events is not working since the IDAM switch over.

- Added back in ignored tests
- Removed the call to the CCD endpoint which was still there just not
being used.
- sscs-common did not set isCorDecision due to a typo.