### PR TITLE
Sscs 3568 additional eveidence cover sheet

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -15,7 +15,8 @@ def secrets = [
                 secret('sscs-s2s-secret', 'IDAM_S2S_AUTH_TOTP_SECRET'),
                 secret('idam-sscs-systemupdate-user', 'IDAM_SSCS_SYSTEMUPDATE_USER'),
                 secret('idam-sscs-systemupdate-password', 'IDAM_SSCS_SYSTEMUPDATE_PASSWORD'),
-                secret('idam-sscs-oauth2-client-secret', 'IDAM_OAUTH2_CLIENT_SECRET')
+                secret('idam-sscs-oauth2-client-secret', 'IDAM_OAUTH2_CLIENT_SECRET'),
+                secret('docmosis-api-key', 'PDF_SERVICE_ACCESS_KEY'),
         ],
         's2s-${env}'      : [
                 secret('microservicekey-ccd-data', 'DATA_STORE_S2S_KEY'),

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -23,6 +23,7 @@ List<LinkedHashMap<String, Object>> secrets = [
         secret('idam-sscs-systemupdate-user', 'IDAM_OAUTH2_USER_EMAIL'),
         secret('idam-sscs-systemupdate-password', 'IDAM_OAUTH2_USER_PASSWORD'),
         secret('idam-sscs-oauth2-client-secret', 'IDAM_OAUTH2_CLIENT_SECRET'),
+        secret('docmosis-api-key', 'PDF_SERVICE_ACCESS_KEY'),
 ]
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.5.RELEASE'
-  id 'org.springframework.boot' version '2.1.2.RELEASE'
+  id 'org.springframework.boot' version '2.1.4.RELEASE'
   id 'org.owasp.dependencycheck' version '5.0.0-M2'
   id 'com.github.ben-manes.versions' version '0.20.0'
   id 'org.sonarqube' version '2.6.2'
@@ -227,7 +227,8 @@ sonarqube {
                 "src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/EvidenceUploadService.java," +
                 "src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java," +
                 "src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/EvidenceDescriptionPdfData.java," +
-                "src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/pdf/PdfEvidenceDescription.java"
+                "src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/pdf/PdfEvidenceDescription.java," +
+                "src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/PdfCoverSheet.java"
     }
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -33,6 +33,11 @@ data "azurerm_key_vault_secret" "idam-sscs-oauth2-client-secret" {
   vault_uri = "${data.azurerm_key_vault.sscs_key_vault.vault_uri}"
 }
 
+data "azurerm_key_vault_secret" "docmosis-api-key" {
+  name = "docmosis-api-key"
+  vault_uri = "${data.azurerm_key_vault.sscs_key_vault.vault_uri}"
+}
+
 locals {
   ase_name = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
 
@@ -91,5 +96,7 @@ module "sscs-core-backend" {
     EMAIL_SERVER_PORT      = "${local.email_port}"
     DWP_EMAIL              = "${var.dwp_email}"
     EMAIL_FROM             = "${var.email_from_address}"
+
+    PDF_SERVICE_ACCESS_KEY = "${data.azurerm_key_vault_secret.docmosis-api-key.value}"
   }
 }

--- a/kubernetes/deployment.template.yaml
+++ b/kubernetes/deployment.template.yaml
@@ -45,6 +45,8 @@ spec:
           value: "mta.reform.hmcts.net"
         - name: EMAIL_SERVER_PORT
           value: "25"
+        - name: PDF_SERVICE_ACCESS_KEY
+          value: "${PDF_SERVICE_ACCESS_KEY}"
 
         envFrom:
           - configMapRef:

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/EvidenceUploadTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/EvidenceUploadTest.java
@@ -56,4 +56,12 @@ public class EvidenceUploadTest extends BaseFunctionTest {
         draftHearingEvidence = sscsCorBackendRequests.getDraftHearingEvidence(hearingWithQuestion.getHearingId());
         assertThat(draftHearingEvidence.length(), is(0));
     }
+
+    @Test
+    public void getEvidenceCoverSheet() throws IOException {
+        OnlineHearing hearing = createHearing(true);
+
+        String coversheet = sscsCorBackendRequests.getCoversheet(hearing.getHearingId());
+        assertThat(coversheet, is("evidence_cover_sheet.pdf"));
+    }
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/SscsCorBackendRequests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/SscsCorBackendRequests.java
@@ -6,6 +6,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -17,6 +18,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
@@ -185,6 +187,14 @@ public class SscsCorBackendRequests {
         HttpResponse getQuestionResponse = postRequest(uri, new StringEntity("{\"body\":\"" + statement + "\"}", APPLICATION_JSON));
 
         assertThat(getQuestionResponse.getStatusLine().getStatusCode(), is(HttpStatus.NO_CONTENT.value()));
+    }
+
+    public String getCoversheet(String hearingId) throws IOException {
+        CloseableHttpResponse getCoverSheetResponse = getRequest("/continuous-online-hearings/" + hearingId + "/evidence/coversheet");
+
+        assertThat(getCoverSheetResponse.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
+        Header fileNameHeader = getCoverSheetResponse.getFirstHeader("Content-Disposition");
+        return ContentDisposition.parse(fileNameHeader.getValue()).getFilename();
     }
 
     private RequestBuilder addHeaders(RequestBuilder requestBuilder) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/Application.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGeneratorFactory;
 import uk.gov.hmcts.reform.sscs.ccd.config.CcdRequestDetails;
+import uk.gov.hmcts.reform.sscs.docmosis.service.DocmosisPdfGenerationService;
 
 @SpringBootApplication
 @EnableCircuitBreaker
@@ -97,5 +98,14 @@ public class Application {
     @Bean
     public HttpClient userTokenParserHttpClient() {
         return serviceTokenParserHttpClient();
+    }
+
+    @Bean
+    public DocmosisPdfGenerationService docmosisPdfGenerationService(
+            @Value("${pdf-service.uri}") String pdfServiceEndpoint,
+            @Value("${pdf-service.accessKey}") String pdfServiceAccessKey,
+            RestTemplate restTemplate
+    ) {
+        return new DocmosisPdfGenerationService(pdfServiceEndpoint, pdfServiceAccessKey, restTemplate);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CoversheetService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/CoversheetService.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+
+@Service
+public class CoversheetService {
+    private final OnlineHearingService onlineHearingService;
+    private final PdfService pdfService;
+    private final String template;
+
+    public CoversheetService(
+            OnlineHearingService onlineHearingService,
+            @Qualifier("docmosisPdfService") PdfService pdfService,
+            @Value("${evidenceCoverSheet.docmosis.template}") String template) {
+        this.onlineHearingService = onlineHearingService;
+        this.pdfService = pdfService;
+        this.template = template;
+    }
+
+    public Optional<byte[]> createCoverSheet(String onlineHearingId) {
+        return onlineHearingService.getCcdCase(onlineHearingId)
+                .map(sscsCase -> {
+                    SscsCaseData sscsCaseData = sscsCase.getData();
+                    Address address = sscsCaseData.getAppeal().getAppellant().getAddress();
+                    PdfCoverSheet pdfCoverSheet = new PdfCoverSheet(
+                            "" + sscsCase.getId(),
+                            address.getLine1(),
+                            address.getLine2(),
+                            address.getTown(),
+                            address.getCounty(),
+                            address.getPostcode()
+                    );
+
+                    return pdfService.createPdf(pdfCoverSheet, template);
+                });
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/PdfCoverSheet.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/PdfCoverSheet.java
@@ -1,0 +1,72 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PdfCoverSheet {
+    @JsonProperty("case_id")
+    private final String caseId;
+    @JsonProperty("address_line1")
+    private final String addressLine1;
+    @JsonProperty("address_line2")
+    private final String addressLine2;
+    @JsonProperty("address_town")
+    private final String addressTown;
+    @JsonProperty("address_county")
+    private final String addressCounty;
+    @JsonProperty("address_postcode")
+    private final String addressPostcode;
+
+    public PdfCoverSheet(String caseId,
+                         String addressLine1,
+                         String addressLine2,
+                         String addressTown,
+                         String addressCounty,
+                         String addressPostcode) {
+        this.caseId = caseId;
+        this.addressLine1 = addressLine1;
+        this.addressLine2 = addressLine2;
+        this.addressTown = addressTown;
+        this.addressCounty = addressCounty;
+        this.addressPostcode = addressPostcode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PdfCoverSheet that = (PdfCoverSheet) o;
+
+        if (caseId != null ? !caseId.equals(that.caseId) : that.caseId != null) {
+            return false;
+        }
+        if (addressLine1 != null ? !addressLine1.equals(that.addressLine1) : that.addressLine1 != null) {
+            return false;
+        }
+        if (addressLine2 != null ? !addressLine2.equals(that.addressLine2) : that.addressLine2 != null) {
+            return false;
+        }
+        if (addressTown != null ? !addressTown.equals(that.addressTown) : that.addressTown != null) {
+            return false;
+        }
+        if (addressCounty != null ? !addressCounty.equals(that.addressCounty) : that.addressCounty != null) {
+            return false;
+        }
+        return addressPostcode != null ? addressPostcode.equals(that.addressPostcode) : that.addressPostcode == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = caseId != null ? caseId.hashCode() : 0;
+        result = 31 * result + (addressLine1 != null ? addressLine1.hashCode() : 0);
+        result = 31 * result + (addressLine2 != null ? addressLine2.hashCode() : 0);
+        result = 31 * result + (addressTown != null ? addressTown.hashCode() : 0);
+        result = 31 * result + (addressCounty != null ? addressCounty.hashCode() : 0);
+        result = 31 * result + (addressPostcode != null ? addressPostcode.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersDeadlineElapsedPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersDeadlineElapsedPdfService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
@@ -13,7 +14,7 @@ public class StoreAnswersDeadlineElapsedPdfService extends AbstractQuestionPdfSe
 
     @SuppressWarnings("squid:S00107")
     public StoreAnswersDeadlineElapsedPdfService(
-            PdfService pdfService,
+            @Qualifier("oldPdfService") PdfService pdfService,
             @Value("${answer.html.template.path}") String templatePath,
             CcdPdfService ccdPdfService,
             IdamService idamService,

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersPdfService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
@@ -13,7 +14,7 @@ public class StoreAnswersPdfService extends AbstractQuestionPdfService {
 
     @SuppressWarnings("squid:S00107")
     public StoreAnswersPdfService(
-            PdfService pdfService,
+            @Qualifier("oldPdfService") PdfService pdfService,
             @Value("${answer.html.template.path}") String templatePath,
             CcdPdfService ccdPdfService,
             IdamService idamService,

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAppellantStatementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAppellantStatementService.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscscorbackend.service;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
@@ -21,7 +22,7 @@ public class StoreAppellantStatementService extends StorePdfService<PdfAppellant
 
     @Autowired
     public StoreAppellantStatementService(
-            PdfService pdfService,
+            @Qualifier("oldPdfService") PdfService pdfService,
             @Value("${personalStatement.html.template.path}")String pdfTemplatePath,
             CcdPdfService ccdPdfService,
             IdamService idamService,

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreEvidenceDescriptionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreEvidenceDescriptionService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
@@ -14,7 +15,7 @@ import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 @Service
 public class StoreEvidenceDescriptionService extends StorePdfService<PdfEvidenceDescription, EvidenceDescriptionPdfData> {
     StoreEvidenceDescriptionService(
-            PdfService pdfService,
+            @Qualifier("oldPdfService") PdfService pdfService,
             @Value("${evidenceDescription.html.template.path}")String pdfTemplatePath,
             CcdPdfService ccdPdfService,
             IdamService idamService,

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
@@ -26,7 +27,7 @@ public class StoreOnlineHearingService extends StorePdfService<PdfSummary, PdfDa
                                      IdamService idamService,
                                      PdfSummaryBuilder pdfSummaryBuilder,
                                      CcdPdfService ccdPdfService,
-                                     PdfService pdfService,
+                                     @Qualifier("oldPdfService") PdfService pdfService,
                                      @Value("${online_hearing_finished.html.template.path}") String templatePath,
                                      EvidenceManagementService evidenceManagementService) {
         super(pdfService, templatePath, ccdPdfService, idamService, evidenceManagementService);

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewService.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscscorbackend.service;
 
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
@@ -24,7 +25,7 @@ public class StoreOnlineHearingTribunalsViewService extends StorePdfService<Onli
 
     @SuppressWarnings("squid:S00107")
     public StoreOnlineHearingTribunalsViewService(OnlineHearingService onlineHearingService,
-                                                  PdfService pdfService,
+                                                  @Qualifier("oldPdfService") PdfService pdfService,
                                                   @Value("${preliminary_view.html.template.path}") String templatePath,
                                                   OnlineHearingDateReformatter onlineHearingDateReformatter,
                                                   CcdPdfService ccdPdfService, IdamService idamService,

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreQuestionsPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreQuestionsPdfService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
@@ -13,7 +14,7 @@ public class StoreQuestionsPdfService extends AbstractQuestionPdfService {
 
     @SuppressWarnings("squid:S00107")
     public StoreQuestionsPdfService(
-            PdfService pdfService,
+            @Qualifier("oldPdfService") PdfService pdfService,
             @Value("${question.html.template.path}") String templatePath,
             CcdPdfService ccdPdfService,
             IdamService idamService,

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/DocmosisPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/DocmosisPdfService.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.docmosis.domain.DocumentHolder;
+import uk.gov.hmcts.reform.sscs.docmosis.domain.Template;
+import uk.gov.hmcts.reform.sscs.docmosis.service.DocmosisPdfGenerationService;
+
+@Service
+public class DocmosisPdfService implements PdfService {
+    private final DocmosisPdfGenerationService docmosisPdfGenerationService;
+
+    public DocmosisPdfService(DocmosisPdfGenerationService docmosisPdfGenerationService) {
+        this.docmosisPdfGenerationService = docmosisPdfGenerationService;
+    }
+
+    @Override
+    public byte[] createPdf(Object pdfSummary, String templatePath) {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Map<String, Object> placeholders = objectMapper.convertValue(
+                pdfSummary,
+                new TypeReference<Map<String, Object>>() {
+                }
+        );
+        return docmosisPdfGenerationService.generatePdf(DocumentHolder.builder()
+                .template(new Template(templatePath, ""))
+                .placeholders(placeholders)
+                .build());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/OldPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/OldPdfService.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.poi.util.IOUtils;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.I18nBuilder;
+
+@Service
+public class OldPdfService implements PdfService {
+    private final PDFServiceClient pdfServiceClient;
+    private final Map i18n;
+    private final Map<String, byte[]> templatesCache;
+
+    public OldPdfService(PDFServiceClient pdfServiceClient, I18nBuilder i18nBuilder) throws IOException {
+        this.pdfServiceClient = pdfServiceClient;
+
+        templatesCache = new HashMap<>();
+        i18n = i18nBuilder.build();
+    }
+
+    @Override
+    public byte[] createPdf(Object pdfSummary, String templatePath) {
+        Map<String, Object> placeholders = ImmutableMap.of("pdfSummary", pdfSummary, "i18n", i18n);
+
+        return pdfServiceClient.generateFromHtml(getTemplate(templatePath), placeholders);
+    }
+
+    private synchronized byte[] getTemplate(String templatePath) {
+        if (!templatesCache.containsKey(templatePath)) {
+            try {
+                templatesCache.put(templatePath, getResource(templatePath));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Cannot load template [" + templatePath + "]");
+            }
+        }
+        return templatesCache.get(templatePath);
+    }
+
+    private byte[] getResource(String file) throws IOException {
+        InputStream in = getClass().getResourceAsStream(file);
+        return IOUtils.toByteArray(in);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/PdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/PdfService.java
@@ -1,47 +1,5 @@
 package uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice;
 
-import com.google.common.collect.ImmutableMap;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
-import org.apache.poi.util.IOUtils;
-import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.pdf.service.client.PDFServiceClient;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.I18nBuilder;
-
-@Service
-public class PdfService {
-    private final PDFServiceClient pdfServiceClient;
-    private final Map i18n;
-    private final Map<String, byte[]> templatesCache;
-
-    public PdfService(PDFServiceClient pdfServiceClient, I18nBuilder i18nBuilder) throws IOException {
-        this.pdfServiceClient = pdfServiceClient;
-
-        templatesCache = new HashMap<>();
-        i18n = i18nBuilder.build();
-    }
-
-    public byte[] createPdf(Object pdfSummary, String templatePath) {
-        Map<String, Object> placeholders = ImmutableMap.of("pdfSummary", pdfSummary, "i18n", i18n);
-
-        return pdfServiceClient.generateFromHtml(getTemplate(templatePath), placeholders);
-    }
-
-    private synchronized byte[] getTemplate(String templatePath) {
-        if (!templatesCache.containsKey(templatePath)) {
-            try {
-                templatesCache.put(templatePath, getResource(templatePath));
-            } catch (IOException e) {
-                throw new IllegalArgumentException("Cannot load template [" + templatePath + "]");
-            }
-        }
-        return templatesCache.get(templatePath);
-    }
-
-    private byte[] getResource(String file) throws IOException {
-        InputStream in = getClass().getResourceAsStream(file);
-        return IOUtils.toByteArray(in);
-    }
+public interface PdfService {
+    byte[] createPdf(Object pdfSummary, String templatePath);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,6 +85,9 @@ evidenceDescription:
   html:
     template:
       path: /templates/evidenceDescription.html
+evidenceCoverSheet:
+  docmosis:
+    template: TB-SCS-GNO-ENG-00012.doc
 
 
 appeal:
@@ -112,3 +115,8 @@ feign:
 
 logging.level:
   org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod: DEBUG
+
+pdf-service:
+  uri: ${PDF_SERVICE_BASE_URL:https://docmosis-development.platform.hmcts.net/rs/render}
+  accessKey: ${PDF_SERVICE_ACCESS_KEY:ZDYxMTkzZTQtMGY2Mi00NDM1LWIyN2ItNGRkNzdjOTczMjAwOjQ1NTE0ODQ}
+

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -118,5 +118,5 @@ logging.level:
 
 pdf-service:
   uri: ${PDF_SERVICE_BASE_URL:https://docmosis-development.platform.hmcts.net/rs/render}
-  accessKey: ${PDF_SERVICE_ACCESS_KEY:ZDYxMTkzZTQtMGY2Mi00NDM1LWIyN2ItNGRkNzdjOTczMjAwOjQ1NTE0ODQ}
+  accessKey: ${PDF_SERVICE_ACCESS_KEY:setMe}
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/CoversheetServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/CoversheetServiceTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+
+public class CoversheetServiceTest {
+
+    private String onlineHearingId;
+    private OnlineHearingService onlineHearingService;
+    private PdfService pdfService;
+    private String template;
+
+    @Before
+    public void setUp() {
+        onlineHearingId = "onlineHearingId";
+        onlineHearingService = mock(OnlineHearingService.class);
+        pdfService = mock(PdfService.class);
+        template = "template";
+    }
+
+    @Test
+    public void canLoadCcdCaseAndProducePdf() {
+        when(onlineHearingService.getCcdCase(onlineHearingId))
+                .thenReturn(Optional.of(createSscsCaseDetails()));
+
+        byte[] pdf = {2, 4, 6, 0, 1};
+        PdfCoverSheet pdfSummary = new PdfCoverSheet("12345", "line1", "line2", "town", "county", "postcode");
+        when(pdfService.createPdf(pdfSummary, template)).thenReturn(pdf);
+
+        Optional<byte[]> pdfOptional =
+                new CoversheetService(onlineHearingService, pdfService, template).createCoverSheet(onlineHearingId);
+
+        assertThat(pdfOptional.isPresent(), is(true));
+        assertThat(pdfOptional.get(), is(pdf));
+    }
+
+    @Test
+    public void cannotLoadCcdCase() {
+        when(onlineHearingService.getCcdCase(onlineHearingId)).thenReturn(Optional.empty());
+
+        Optional<byte[]> pdfOptional =
+                new CoversheetService(onlineHearingService, pdfService, template).createCoverSheet(onlineHearingId);
+
+        assertThat(pdfOptional.isPresent(), is(false));
+    }
+
+    private SscsCaseDetails createSscsCaseDetails() {
+        return SscsCaseDetails.builder()
+                .id(12345L)
+                .data(SscsCaseData.builder()
+                        .appeal(Appeal.builder()
+                                .appellant(Appellant.builder()
+                                        .address(Address.builder()
+                                                .line1("line1")
+                                                .line2("line2")
+                                                .town("town")
+                                                .county("county")
+                                                .postcode("postcode")
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersDeadlineElapsedPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersDeadlineElapsedPdfServiceTest.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
 import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfData;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 
 public class StoreAnswersDeadlineElapsedPdfServiceTest {
 
@@ -28,7 +28,7 @@ public class StoreAnswersDeadlineElapsedPdfServiceTest {
         questionService = mock(QuestionService.class);
         onlineHearingId = "someOnlineHearingId";
         storeQuestionsPdfService = new StoreAnswersDeadlineElapsedPdfService(
-                mock(PdfService.class), "sometemplate", mock(CcdPdfService.class), mock(IdamService.class),
+                mock(OldPdfService.class), "sometemplate", mock(CcdPdfService.class), mock(IdamService.class),
                 questionService, mock(EvidenceManagementService.class));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAnswersPdfServiceTest.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
 import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfData;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 
 public class StoreAnswersPdfServiceTest {
 
@@ -28,7 +28,7 @@ public class StoreAnswersPdfServiceTest {
         questionService = mock(QuestionService.class);
         onlineHearingId = "someOnlineHearingId";
         storeQuestionsPdfService = new StoreAnswersPdfService(
-                mock(PdfService.class), "sometemplate", mock(CcdPdfService.class), mock(IdamService.class),
+                mock(OldPdfService.class), "sometemplate", mock(CcdPdfService.class), mock(IdamService.class),
                 questionService, mock(EvidenceManagementService.class));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAppellantStatementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreAppellantStatementServiceTest.java
@@ -14,7 +14,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentDetails;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.CcdPdfService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 
 public class StoreAppellantStatementServiceTest {
 
@@ -23,7 +23,7 @@ public class StoreAppellantStatementServiceTest {
     @Before
     public void setUp() {
         storeAppellantStatementService = new StoreAppellantStatementService(
-                mock(PdfService.class),
+                mock(OldPdfService.class),
                 "templatePath",
                 mock(CcdPdfService.class),
                 mock(IdamService.class),

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreEvidenceDescriptionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreEvidenceDescriptionServiceTest.java
@@ -17,7 +17,7 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.EvidenceDescription;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfEvidenceDescription;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.EvidenceDescriptionPdfData;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 
 public class StoreEvidenceDescriptionServiceTest {
     private StoreEvidenceDescriptionService storeEvidenceDescriptionService;
@@ -25,7 +25,7 @@ public class StoreEvidenceDescriptionServiceTest {
     @Before
     public void setUp() throws Exception {
         storeEvidenceDescriptionService = new StoreEvidenceDescriptionService(
-                mock(PdfService.class),
+                mock(OldPdfService.class),
                 "template_path",
                 mock(CcdPdfService.class),
                 mock(IdamService.class),

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingServiceTest.java
@@ -16,7 +16,7 @@ import uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfData;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfSummaryBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.CohService;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.api.CohConversations;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 
 public class StoreOnlineHearingServiceTest {
 
@@ -36,7 +36,7 @@ public class StoreOnlineHearingServiceTest {
 
         underTest = new StoreOnlineHearingService(
                 cohService, mock(IdamService.class), pdfSummaryBuilder,
-                mock(CcdPdfService.class), mock(PdfService.class), "sometemplate",
+                mock(CcdPdfService.class), mock(OldPdfService.class), "sometemplate",
                 mock(EvidenceManagementService.class));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreOnlineHearingTribunalsViewServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscscorbackend.domain.OnlineHearing;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfData;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 public class StoreOnlineHearingTribunalsViewServiceTest {
@@ -35,7 +36,7 @@ public class StoreOnlineHearingTribunalsViewServiceTest {
     public void setUp() throws IOException {
         onlineHearingService = mock(OnlineHearingService.class);
         onlineHearingDateReformatter = mock(OnlineHearingDateReformatter.class);
-        pdfService = mock(PdfService.class);
+        pdfService = mock(OldPdfService.class);
         ccdPdfService = mock(CcdPdfService.class);
         IdamService idamService = mock(IdamService.class);
         idamTokens = mock(IdamTokens.class);

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfData;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 public class StorePdfServiceTest {
@@ -38,7 +39,7 @@ public class StorePdfServiceTest {
 
     @Before
     public void setUp() {
-        pdfService = mock(PdfService.class);
+        pdfService = mock(OldPdfService.class);
         sscsPdfService = mock(CcdPdfService.class);
         IdamService idamService = mock(IdamService.class);
         idamTokens = IdamTokens.builder().build();

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreQuestionsPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StoreQuestionsPdfServiceTest.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
 import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfData;
-import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
+import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 
 public class StoreQuestionsPdfServiceTest {
 
@@ -28,7 +28,7 @@ public class StoreQuestionsPdfServiceTest {
         questionService = mock(QuestionService.class);
         onlineHearingId = "someOnlineHearingId";
         storeQuestionsPdfService = new StoreQuestionsPdfService(
-                mock(PdfService.class), "sometemplate", mock(CcdPdfService.class), mock(IdamService.class),
+                mock(OldPdfService.class), "sometemplate", mock(CcdPdfService.class), mock(IdamService.class),
                 questionService, mock(EvidenceManagementService.class));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/DocmosisPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/DocmosisPdfServiceTest.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.docmosis.service.DocmosisPdfGenerationService;
+import uk.gov.hmcts.reform.sscscorbackend.service.PdfCoverSheet;
+
+public class DocmosisPdfServiceTest {
+
+    private byte[] expectedPdf;
+    private String template;
+    private HashMap<String, Object> expectedPlaceholders;
+    private PdfCoverSheet pdfCoverSheet;
+    private DocmosisPdfGenerationService docmosisPdfGenerationService;
+
+    @Before
+    public void setUp() {
+        expectedPdf = new byte[]{2, 4, 6, 0, 1};
+        template = "template";
+
+        expectedPlaceholders = new HashMap<>();
+        expectedPlaceholders.put("case_id", "caseId");
+        expectedPlaceholders.put("address_line1", "addressLine1");
+        expectedPlaceholders.put("address_line2", "addressLine2");
+        expectedPlaceholders.put("address_town", "addressTown");
+        expectedPlaceholders.put("address_county", "addressCounty");
+        expectedPlaceholders.put("address_postcode", "addressPostcode");
+
+        pdfCoverSheet = new PdfCoverSheet(
+                "caseId", "addressLine1", "addressLine2", "addressTown", "addressCounty", "addressPostcode"
+        );
+        docmosisPdfGenerationService = mock(DocmosisPdfGenerationService.class);
+    }
+
+    @Test
+    public void canCreatePdf() {
+        when(docmosisPdfGenerationService.generatePdf(
+                argThat(argument ->
+                        argument.getPlaceholders().equals(expectedPlaceholders) &&
+                                argument.getTemplate().getTemplateName().equals(template) &&
+                                argument.getTemplate().getHmctsDocName().equals("")
+                )
+        )).thenReturn(expectedPdf);
+
+        byte[] pdfBytes = new DocmosisPdfService(docmosisPdfGenerationService).createPdf(pdfCoverSheet, template);
+
+        assertThat(pdfBytes, is(expectedPdf));
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/OldPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/OldPdfServiceTest.java
@@ -16,14 +16,14 @@ import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfSummary;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.I18nBuilder;
 
-public class PdfServiceTest {
+public class OldPdfServiceTest {
     @Test
     public void createsPdf() throws IOException {
         PDFServiceClient pdfServiceClient = mock(PDFServiceClient.class);
         I18nBuilder i18nBuilder = mock(I18nBuilder.class);
         HashMap i18n = new HashMap();
         when(i18nBuilder.build()).thenReturn(i18n);
-        PdfService appellantTemplatePath = new PdfService(pdfServiceClient, i18nBuilder);
+        PdfService appellantTemplatePath = new OldPdfService(pdfServiceClient, i18nBuilder);
 
         PdfSummary pdfSummary = DataFixtures.somePdfSummary();
 


### PR DESCRIPTION
Added an endpoint to create a coversheet which an appellant should print
out when posting in additional evidence.

The coversheet is created using the new Docmosis system. This will 
replace the old Pdf generator. Eventually all PDFs should be generated 
using Docmosis. Have created an interface PdfService that has Docmosis 
and old pdf service implementations.