### PR TITLE
SSCS-4785 Send DWP appellant statement

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/AppellantStatementTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/AppellantStatementTest.java
@@ -10,8 +10,7 @@ public class AppellantStatementTest extends BaseIntegrationTest {
     private final Long caseId = 123L;
     private final String hearingId = "hearingId";
     private String caseReference = "caseReference";
-
-
+    
     @Test
     public void recordRejectedResponse() throws JsonProcessingException {
         cohStub.stubGetOnlineHearing(caseId, hearingId);
@@ -30,6 +29,6 @@ public class AppellantStatementTest extends BaseIntegrationTest {
                 .then()
                 .statusCode(HttpStatus.NO_CONTENT.value());
 
-        mailStub.hasEmailWithSubjectAndAttachment("Appellant statement (caseReference)", pdf);
+        mailStub.hasEmailWithSubjectAndAttachment("COR: Additional evidence submitted (caseReference)", pdf);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/AppellantStatementTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/AppellantStatementTest.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.sscscorbackend;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+public class AppellantStatementTest extends BaseIntegrationTest {
+    private final Long caseId = 123L;
+    private final String hearingId = "hearingId";
+    private String caseReference = "caseReference";
+
+
+    @Test
+    public void recordRejectedResponse() throws JsonProcessingException {
+        cohStub.stubGetOnlineHearing(caseId, hearingId);
+
+        ccdStub.stubFindCaseByCaseId(caseId, caseReference, "first-id", "someEvidence", "evidenceCreatedDate", "http://example.com/document/1");
+        documentStoreStub.stubUploadFile();
+        byte[] pdf = {2, 4, 6, 0, 1};
+        pdfServiceStub.stubCreatePdf(pdf);
+        ccdStub.stubUpdateCase(caseId, caseReference);
+
+        getRequest()
+                .body("{\"body\":\"some appellant statement\"}")
+                .when()
+                .contentType(APPLICATION_JSON_VALUE)
+                .post("/continuous-online-hearings/" + hearingId + "/statement")
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        mailStub.hasEmailWithSubjectAndAttachment("Appellant statement (caseReference)", pdf);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/StatementController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/StatementController.java
@@ -9,21 +9,17 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.hmcts.reform.sscscorbackend.domain.Statement;
-import uk.gov.hmcts.reform.sscscorbackend.service.OnlineHearingService;
-import uk.gov.hmcts.reform.sscscorbackend.service.StoreAppellantStatementService;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.AppellantStatementPdfData;
+import uk.gov.hmcts.reform.sscscorbackend.service.AppellantStatementService;
 
 @Slf4j
 @RestController
 @RequestMapping("/continuous-online-hearings")
 public class StatementController {
-    private final StoreAppellantStatementService storeAppellantStatementService;
-    private final OnlineHearingService onlineHearingService;
+    private final AppellantStatementService appellantStatementService;
 
     @Autowired
-    public StatementController(StoreAppellantStatementService storeAppellantStatementService, OnlineHearingService onlineHearingService) {
-        this.storeAppellantStatementService = storeAppellantStatementService;
-        this.onlineHearingService = onlineHearingService;
+    public StatementController(AppellantStatementService appellantStatementService) {
+        this.appellantStatementService = appellantStatementService;
     }
 
     @ApiOperation(value = "Upload COR personal statement",
@@ -42,9 +38,9 @@ public class StatementController {
             @PathVariable("onlineHearingId") String onlineHearingId,
             @RequestBody Statement statement) {
 
-        return onlineHearingService.getCcdCase(onlineHearingId).map(caseDetails -> {
-            storeAppellantStatementService.storePdf(caseDetails.getId(), onlineHearingId, new AppellantStatementPdfData(caseDetails, statement));
-            return ResponseEntity.noContent().build();
-        }).orElse(ResponseEntity.notFound().build());
+        return appellantStatementService
+                .handleAppellantStatement(onlineHearingId, statement)
+                .map(handled -> ResponseEntity.noContent().build())
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/pdf/PdfAppealDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/pdf/PdfAppealDetails.java
@@ -1,20 +1,20 @@
 package uk.gov.hmcts.reform.sscscorbackend.domain.pdf;
 
-import java.util.Objects;
-
 public class PdfAppealDetails {
     private final String title;
     private final String firstName;
     private final String surname;
     private final String nino;
     private final String caseReference;
+    private final String dateCreated;
 
-    public PdfAppealDetails(String title, String firstName, String surname, String nino, String caseReference) {
+    public PdfAppealDetails(String title, String firstName, String surname, String nino, String caseReference, String dateCreated) {
         this.title = title;
         this.firstName = firstName;
         this.surname = surname;
         this.nino = nino;
         this.caseReference = caseReference;
+        this.dateCreated = dateCreated;
     }
 
     public String getTitle() {
@@ -37,6 +37,10 @@ public class PdfAppealDetails {
         return caseReference;
     }
 
+    public String getDateCreated() {
+        return dateCreated;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -45,17 +49,36 @@ public class PdfAppealDetails {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+
         PdfAppealDetails that = (PdfAppealDetails) o;
-        return Objects.equals(title, that.title) &&
-                Objects.equals(firstName, that.firstName) &&
-                Objects.equals(surname, that.surname) &&
-                Objects.equals(nino, that.nino) &&
-                Objects.equals(caseReference, that.caseReference);
+
+        if (title != null ? !title.equals(that.title) : that.title != null) {
+            return false;
+        }
+        if (firstName != null ? !firstName.equals(that.firstName) : that.firstName != null) {
+            return false;
+        }
+        if (surname != null ? !surname.equals(that.surname) : that.surname != null) {
+            return false;
+        }
+        if (nino != null ? !nino.equals(that.nino) : that.nino != null) {
+            return false;
+        }
+        if (caseReference != null ? !caseReference.equals(that.caseReference) : that.caseReference != null) {
+            return false;
+        }
+        return dateCreated != null ? dateCreated.equals(that.dateCreated) : that.dateCreated == null;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(title, firstName, surname, nino, caseReference);
+        int result = title != null ? title.hashCode() : 0;
+        result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
+        result = 31 * result + (surname != null ? surname.hashCode() : 0);
+        result = 31 * result + (nino != null ? nino.hashCode() : 0);
+        result = 31 * result + (caseReference != null ? caseReference.hashCode() : 0);
+        result = 31 * result + (dateCreated != null ? dateCreated.hashCode() : 0);
+        return result;
     }
 
     @Override
@@ -66,6 +89,7 @@ public class PdfAppealDetails {
                 ", surname='" + surname + '\'' +
                 ", nino='" + nino + '\'' +
                 ", caseReference='" + caseReference + '\'' +
+                ", dateCreated='" + dateCreated + '\'' +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementEmailService.java
@@ -16,7 +16,7 @@ public class AppellantStatementEmailService {
     public void sendEmail(CohEventActionContext cohEventActionContext) {
         String message = emailMessageBuilder.getAppellantStatementMessage(cohEventActionContext.getDocument());
 
-        String subject = "Appellant statement (" + cohEventActionContext.getDocument().getData().getCaseReference() + ")";
+        String subject = "COR: Additional evidence submitted (" + cohEventActionContext.getDocument().getData().getCaseReference() + ")";
         corEmailService.sendPdfToDwp(cohEventActionContext, subject, message);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementEmailService.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+@Service
+public class AppellantStatementEmailService {
+    private final CorEmailService corEmailService;
+    private final EmailMessageBuilder emailMessageBuilder;
+
+    public AppellantStatementEmailService(CorEmailService corEmailService, EmailMessageBuilder emailMessageBuilder) {
+        this.corEmailService = corEmailService;
+        this.emailMessageBuilder = emailMessageBuilder;
+    }
+
+    public void sendEmail(CohEventActionContext cohEventActionContext) {
+        String message = emailMessageBuilder.getAppellantStatementMessage(cohEventActionContext.getDocument());
+
+        String subject = "Appellant statement (" + cohEventActionContext.getDocument().getData().getCaseReference() + ")";
+        corEmailService.sendPdfToDwp(cohEventActionContext, subject, message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementService.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscscorbackend.domain.Statement;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.AppellantStatementPdfData;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+@Service
+public class AppellantStatementService {
+    private final StoreAppellantStatementService storeAppellantStatementService;
+    private final OnlineHearingService onlineHearingService;
+    private final AppellantStatementEmailService appellantStatementEmailService;
+
+    @Autowired
+    public AppellantStatementService(
+            StoreAppellantStatementService storeAppellantStatementService,
+            OnlineHearingService onlineHearingService,
+            AppellantStatementEmailService appellantStatementEmailService) {
+        this.storeAppellantStatementService = storeAppellantStatementService;
+        this.onlineHearingService = onlineHearingService;
+        this.appellantStatementEmailService = appellantStatementEmailService;
+    }
+
+    public Optional<CohEventActionContext> handleAppellantStatement(String onlineHearingId, Statement statement) {
+        return onlineHearingService.getCcdCase(onlineHearingId).map(caseDetails -> {
+            CohEventActionContext cohEventActionContext = storeAppellantStatementService.storePdf(
+                    caseDetails.getId(),
+                    onlineHearingId,
+                    new AppellantStatementPdfData(caseDetails, statement)
+            );
+            appellantStatementEmailService.sendEmail(cohEventActionContext);
+
+            return cohEventActionContext;
+        });
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/EmailMessageBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/EmailMessageBuilder.java
@@ -68,6 +68,10 @@ public class EmailMessageBuilder {
                 "Reasons for requesting a hearing:\n\n" + reason);
     }
 
+    public String getAppellantStatementMessage(SscsCaseDetails sscsCaseDetails) {
+        return buildMessage(sscsCaseDetails, "The appellant has added a statement to their appeal.");
+    }
+
     private String buildMessageWithHeading(SscsCaseDetails caseDetails, String message, String heading) {
         String templateWithHeading = TEMPLATE_WITH_HEADING.replace("{heading}", heading);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/EmailMessageBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/EmailMessageBuilder.java
@@ -69,7 +69,11 @@ public class EmailMessageBuilder {
     }
 
     public String getAppellantStatementMessage(SscsCaseDetails sscsCaseDetails) {
-        return buildMessage(sscsCaseDetails, "The appellant has added a statement to their appeal.");
+        return buildMessageWithHeading(
+                sscsCaseDetails,
+                "The appellant has written a statement online and submitted it to the tribunal. Their statement is attached.",
+                "Additional evidence submitted"
+        );
     }
 
     private String buildMessageWithHeading(SscsCaseDetails caseDetails, String message, String heading) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingDateReformatter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingDateReformatter.java
@@ -1,10 +1,8 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.DecodeJsonUtil.decodeStringWithWhitespace;
+import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfDateUtil.reformatDate;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscscorbackend.domain.Decision;
 import uk.gov.hmcts.reform.sscscorbackend.domain.OnlineHearing;
@@ -34,12 +32,5 @@ public class OnlineHearingDateReformatter {
                 newDecision,
                 onlineHearing.getFinalDecision(),
                 onlineHearing.isHasFinalDecision());
-    }
-
-    private String reformatDate(String dateString) {
-        if (isNotBlank(dateString)) {
-            return LocalDate.parse(dateString).format(DateTimeFormatter.ofPattern("dd MMMM yyyy"));
-        }
-        return dateString;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfService.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.sscscorbackend.service;
 
+import static java.time.LocalDate.now;
+import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfDateUtil.reformatDate;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -101,8 +104,9 @@ public abstract class StorePdfService<E, D extends PdfData> {
 
         String nino = caseDetails.getData().getAppeal().getAppellant().getIdentity().getNino();
         String caseReference = caseDetails.getData().getCaseReference();
+        String dateCreated = reformatDate(now());
 
-        return new PdfAppealDetails(appellantTitle, appellantFirstName, appellantLastName, nino, caseReference);
+        return new PdfAppealDetails(appellantTitle, appellantFirstName, appellantLastName, nino, caseReference, dateCreated);
     }
 
     protected abstract String documentNamePrefix(SscsCaseDetails caseDetails, String onlineHearingId);

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/PdfDateUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/PdfDateUtil.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.sscscorbackend.service.pdf;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public final class PdfDateUtil {
+
+    private static final String PDF_DATE_FORMAT = "dd MMMM yyyy";
+
+    private PdfDateUtil() {
+
+    }
+
+    public static String reformatDate(String dateString) {
+        if (isNotBlank(dateString)) {
+            return reformatDate(LocalDate.parse(dateString));
+        }
+        return dateString;
+    }
+
+    public static String reformatDate(LocalDate date) {
+        return date.format(DateTimeFormatter.ofPattern(PDF_DATE_FORMAT));
+    }
+}

--- a/src/main/resources/templates/answers.html
+++ b/src/main/resources/templates/answers.html
@@ -143,6 +143,14 @@
                             {{ pdfSummary.appealDetails.caseReference }}
                         </dd>
                     </div>
+                    <div>
+                        <dt class="cya-question">
+                            Date created
+                        </dt>
+                        <dd class="cya-answer">
+                            {{ pdfSummary.appealDetails.dateCreated }}
+                        </dd>
+                    </div>
                 </dl>
                 {% for question in pdfSummary.questions %}
                     <h2 class="heading-medium">{{ question.question_header_text }}</h2>

--- a/src/main/resources/templates/evidenceDescription.html
+++ b/src/main/resources/templates/evidenceDescription.html
@@ -115,6 +115,14 @@
                             {{ pdfSummary.appealDetails.caseReference }}
                         </dd>
                     </div>
+                    <div>
+                        <dt class="cya-question">
+                            Date created
+                        </dt>
+                        <dd class="cya-answer">
+                            {{ pdfSummary.appealDetails.dateCreated }}
+                        </dd>
+                    </div>
                 </dl>
                 <p>{{ pdfSummary.description }}</p>
                 <p>For the following files</p>

--- a/src/main/resources/templates/evidenceDescription.html
+++ b/src/main/resources/templates/evidenceDescription.html
@@ -70,7 +70,7 @@
     <div style="margin: 0px 45px 100px 45px;">
         <div class="grid-row">
             <div class="column-full">
-                <h1 class="heading-large">Evidence Description</h1>
+                <h1 class="heading-large">Evidence description</h1>
                 <br/>
 
                 <dl class="govuk-check-your-answers cya-questions-short">

--- a/src/main/resources/templates/onlineHearingSummary.html
+++ b/src/main/resources/templates/onlineHearingSummary.html
@@ -152,6 +152,14 @@
                             {{ pdfSummary.appealDetails.caseReference }}
                         </dd>
                     </div>
+                    <div>
+                        <dt class="cya-question">
+                            Date created
+                        </dt>
+                        <dd class="cya-answer">
+                            {{ pdfSummary.appealDetails.dateCreated }}
+                        </dd>
+                    </div>
                 </dl>
                 <div class="govuk-check-your-answers">
                     <h2 class="heading-medium">Relisting reason</h2>

--- a/src/main/resources/templates/personalStatement.html
+++ b/src/main/resources/templates/personalStatement.html
@@ -70,7 +70,7 @@
     <div style="margin: 0px 45px 100px 45px;">
         <div class="grid-row">
             <div class="column-full">
-                <h1 class="heading-large">Appellant Statement</h1>
+                <h1 class="heading-large">Appellant statement</h1>
                 <br/>
 
                 <dl class="govuk-check-your-answers cya-questions-short">

--- a/src/main/resources/templates/personalStatement.html
+++ b/src/main/resources/templates/personalStatement.html
@@ -115,6 +115,14 @@
                             {{ pdfSummary.appealDetails.caseReference }}
                         </dd>
                     </div>
+                    <div>
+                        <dt class="cya-question">
+                            Date created
+                        </dt>
+                        <dd class="cya-answer">
+                            {{ pdfSummary.appealDetails.dateCreated }}
+                        </dd>
+                    </div>
                 </dl>
                     <p>{{ pdfSummary.statement }}</p>
                 <span class="font-size: 12px">

--- a/src/main/resources/templates/questions.html
+++ b/src/main/resources/templates/questions.html
@@ -140,6 +140,14 @@
                             {{ pdfSummary.appealDetails.caseReference }}
                         </dd>
                     </div>
+                    <div>
+                        <dt class="cya-question">
+                            Date created
+                        </dt>
+                        <dd class="cya-answer">
+                            {{ pdfSummary.appealDetails.dateCreated }}
+                        </dd>
+                    </div>
                 </dl>
                 {% for question in pdfSummary.questions %}
                     <h2 class="heading-medium">{{ question.question_header_text }}</h2>

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -153,7 +153,7 @@ public class DataFixtures {
     }
 
     public static PdfAppealDetails somePdfAppealDetails() {
-        return new PdfAppealDetails("someTitle", "someFirstName", "someSurname", "someNino", "someCaseRef");
+        return new PdfAppealDetails("someTitle", "someFirstName", "someSurname", "someNino", "someCaseRef", "someDate");
     }
 
     public static Decision someDecision() {

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -171,4 +171,8 @@ public class DataFixtures {
                 )
         );
     }
+
+    public static Statement someStatement() {
+        return new Statement("Some Statement body");
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementEmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementEmailServiceTest.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.Pdf;
+
+public class AppellantStatementEmailServiceTest {
+
+    private CorEmailService corEmailService;
+    private EmailMessageBuilder emailMessageBuilder;
+    private AppellantStatementEmailService appellantStatementEmailService;
+
+    @Before
+    public void setUp() {
+        corEmailService = mock(CorEmailService.class);
+        emailMessageBuilder = mock(EmailMessageBuilder.class);
+
+        appellantStatementEmailService = new AppellantStatementEmailService(corEmailService, emailMessageBuilder);
+    }
+
+    @Test
+    public void sendsAppellantStatementEmailToDwp() {
+        String caseRef = "caseRef";
+        SscsCaseDetails sscsCaseDetails = SscsCaseDetails.builder().data(SscsCaseData.builder()
+                .caseReference(caseRef)
+                .build()).build();
+        CohEventActionContext cohEventActionContext = new CohEventActionContext(mock(Pdf.class), sscsCaseDetails);
+        String message = "message body";
+        when(emailMessageBuilder.getAppellantStatementMessage(sscsCaseDetails)).thenReturn(message);
+
+        appellantStatementEmailService.sendEmail(cohEventActionContext);
+
+        verify(corEmailService).sendPdfToDwp(cohEventActionContext, "Appellant statement (" + caseRef + ")", message);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementEmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementEmailServiceTest.java
@@ -35,7 +35,7 @@ public class AppellantStatementEmailServiceTest {
 
         appellantStatementEmailService.sendEmail(cohEventActionContext);
 
-        verify(corEmailService).sendPdfToDwp(cohEventActionContext, "Appellant statement (" + caseRef + ")", message);
+        verify(corEmailService).sendPdfToDwp(cohEventActionContext, "COR: Additional evidence submitted (" + caseRef + ")", message);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementServiceTest.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.sscscorbackend.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someStatement;
+
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.AppellantStatementPdfData;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+
+public class AppellantStatementServiceTest {
+
+    private StoreAppellantStatementService storeAppellantStatementService;
+    private OnlineHearingService onlineHearingService;
+    private AppellantStatementEmailService appellantStatementEmailService;
+    private AppellantStatementService appellantStatementService;
+    private String someOnlineHearing;
+
+    @Before
+    public void setUp() {
+        storeAppellantStatementService = mock(StoreAppellantStatementService.class);
+        onlineHearingService = mock(OnlineHearingService.class);
+        appellantStatementEmailService = mock(AppellantStatementEmailService.class);
+
+        appellantStatementService = new AppellantStatementService(
+                storeAppellantStatementService, onlineHearingService, appellantStatementEmailService
+        );
+        someOnlineHearing = "someOnlineHearing";
+    }
+
+    @Test
+    public void cannotFindOnlineHearing() {
+        when(onlineHearingService.getCcdCase(someOnlineHearing)).thenReturn(Optional.empty());
+        Optional handled = appellantStatementService.handleAppellantStatement(someOnlineHearing, someStatement());
+
+        assertThat(handled, is(Optional.empty()));
+    }
+
+    @Test
+    public void findsOnlineHearing() {
+        long id = 1234L;
+        when(onlineHearingService.getCcdCase(someOnlineHearing)).thenReturn(Optional.of(SscsCaseDetails.builder().id(id).build()));
+        when(storeAppellantStatementService.storePdf(eq(id), eq(someOnlineHearing), any(AppellantStatementPdfData.class)))
+                .thenReturn(mock(CohEventActionContext.class));
+        Optional handled = appellantStatementService.handleAppellantStatement(someOnlineHearing, someStatement());
+
+        assertThat(handled.isPresent(), is(true));
+    }
+
+    @Test
+    public void generatesAndSavesPdf() {
+        long id = 1234L;
+        when(onlineHearingService.getCcdCase(someOnlineHearing)).thenReturn(Optional.of(SscsCaseDetails.builder().id(id).build()));
+        CohEventActionContext cohEventActionContext = mock(CohEventActionContext.class);
+        when(storeAppellantStatementService.storePdf(eq(id), eq(someOnlineHearing), any(AppellantStatementPdfData.class)))
+                .thenReturn(cohEventActionContext);
+        Optional handled = appellantStatementService.handleAppellantStatement(someOnlineHearing, someStatement());
+
+        assertThat(handled.isPresent(), is(true));
+        verify(appellantStatementEmailService).sendEmail(cohEventActionContext);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/EmailMessageBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/EmailMessageBuilderTest.java
@@ -147,11 +147,13 @@ public class EmailMessageBuilderTest {
         String message = new EmailMessageBuilder().getAppellantStatementMessage(caseDetails);
 
         assertThat(message, is(
+                "Additional evidence submitted\n" +
+                "\n" +
                 "Appeal reference number: caseReference\n" +
                 "Appellant name: Jean Valjean\n" +
                 "Appellant NINO: JV123456\n" +
                 "\n" +
-                "The appellant has added a statement to their appeal.\n" +
+                "The appellant has written a statement online and submitted it to the tribunal. Their statement is attached.\n" +
                 "\n" +
                 "PIP Benefit Appeals\n" +
                 "HMCTS\n"));

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/EmailMessageBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/EmailMessageBuilderTest.java
@@ -141,4 +141,19 @@ public class EmailMessageBuilderTest {
                 "PIP Benefit Appeals\n" +
                 "HMCTS\n"));
     }
+
+    @Test
+    public void buildAppellantStatement() {
+        String message = new EmailMessageBuilder().getAppellantStatementMessage(caseDetails);
+
+        assertThat(message, is(
+                "Appeal reference number: caseReference\n" +
+                "Appellant name: Jean Valjean\n" +
+                "Appellant NINO: JV123456\n" +
+                "\n" +
+                "The appellant has added a statement to their appeal.\n" +
+                "\n" +
+                "PIP Benefit Appeals\n" +
+                "HMCTS\n"));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/PdfDateUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/PdfDateUtilTest.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.sscscorbackend.service.pdf;
+
+import static java.time.LocalDate.parse;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.PdfDateUtil.reformatDate;
+
+import org.junit.Test;
+
+public class PdfDateUtilTest {
+    @Test
+    public void canHandleBlankDate() {
+        String reformatDate = reformatDate("");
+
+        assertThat(reformatDate, is(""));
+    }
+
+    @Test
+    public void formatsStringDate() {
+        String reformatDate = reformatDate("2001-06-24");
+
+        assertThat(reformatDate, is("24 June 2001"));
+    }
+
+    @Test
+    public void formatsLocalDate() {
+        String reformatDate = reformatDate(parse("2001-06-24"));
+
+        assertThat(reformatDate, is("24 June 2001"));
+    }
+}


### PR DESCRIPTION
When the appellant writes a statement it is saved as a PDF as evidence
in CCD. This also needs to be sent to DWP as an attachment to an email.

https://tools.hmcts.net/jira/browse/SSCS-4785

```
[ ] Yes
[X ] No
```
