### PR TITLE
SSCS-5463 Set evidence type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,7 +164,7 @@ dependencies {
   compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
   compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '2.0.1'
 
-  compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.0.1'
+  compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.0.2'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '5.0.0'
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '5.0.1'
   compile group: 'uk.gov.hmcts.reform.auth', name: 'auth-checker-lib', version: '2.1.3'

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfService.java
@@ -62,7 +62,7 @@ public abstract class StorePdfService<E, D extends PdfData> {
         SscsCaseData caseData = caseDetails.getData();
         String pdfName = getPdfName(documentNamePrefix, caseData.getCaseReference());
         log.info("Adding pdf to ccd for [" + caseId + "]");
-        SscsCaseData sscsCaseData = ccdPdfService.mergeDocIntoCcd(pdfName, pdfBytes, caseId, caseData, idamTokens);
+        SscsCaseData sscsCaseData = ccdPdfService.mergeDocIntoCcd(pdfName, pdfBytes, caseId, caseData, idamTokens, "Other evidence");
 
         return new CohEventActionContext(new Pdf(pdfBytes, pdfName), data.getCaseDetails().toBuilder().data(sscsCaseData).build());
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/StorePdfServiceTest.java
@@ -69,12 +69,12 @@ public class StorePdfServiceTest {
         byte[] expectedPdfBytes = {2, 4, 6, 0, 1};
         when(pdfService.createPdf(pdfContent, "sometemplate")).thenReturn(expectedPdfBytes);
         String expectedCaseId = "expectedCcdCaseId";
-        when(sscsPdfService.mergeDocIntoCcd(fileNamePrefix + CASE_REF + ".pdf", expectedPdfBytes, caseId, caseDetails.getData(), idamTokens))
+        when(sscsPdfService.mergeDocIntoCcd(fileNamePrefix + CASE_REF + ".pdf", expectedPdfBytes, caseId, caseDetails.getData(), idamTokens, "Other evidence"))
                 .thenReturn(SscsCaseData.builder().ccdCaseId(expectedCaseId).build());
 
         CohEventActionContext cohEventActionContext = storePdfService.storePdf(caseId, someOnlineHearingId, new PdfData(caseDetails));
 
-        verify(sscsPdfService).mergeDocIntoCcd(fileNamePrefix + CASE_REF + ".pdf", expectedPdfBytes, caseId, caseDetails.getData(), idamTokens);
+        verify(sscsPdfService).mergeDocIntoCcd(fileNamePrefix + CASE_REF + ".pdf", expectedPdfBytes, caseId, caseDetails.getData(), idamTokens, "Other evidence");
         assertThat(cohEventActionContext.getPdf().getContent(), is(expectedPdfBytes));
         assertThat(cohEventActionContext.getPdf().getName(), is(fileNamePrefix + CASE_REF + ".pdf"));
         assertThat(cohEventActionContext.getDocument().getData().getCcdCaseId(), is(expectedCaseId));


### PR DESCRIPTION
When we create a PDF we should to set the document type to
'Other evidence' which is then stored in CCD. The ability to do this has
been added to the sscs-pdf-email-common library so we need to start
doing it. Then we can remove the old method from the library where
document type is not set.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-5463

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
