### PR TITLE
SSCS-5470 Set question evidence as draft

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -72,4 +72,8 @@
     <cve>CVE-2014-3488</cve>
     <cve>CVE-2015-2156</cve>
   </suppress>
+  <suppress>
+    <notes>We don't use the CGI Servlet</notes>
+    <cve>CVE-2019-0232</cve>
+  </suppress>
 </suppressions>

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/EvidenceUploadTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/EvidenceUploadTest.java
@@ -34,6 +34,28 @@ public class EvidenceUploadTest extends BaseFunctionTest {
     }
 
     @Test
+    public void uploadThenEvidenceThenSubmitQuestion() throws IOException, InterruptedException, JSONException {
+        OnlineHearing hearingWithQuestion = createHearingWithQuestion(true);
+
+        JSONObject questionResponse = sscsCorBackendRequests.getQuestion(hearingWithQuestion.getHearingId(), hearingWithQuestion.getQuestionId());
+        assertThat(questionResponse.has("evidence"), is(false));
+
+        String fileName = "evidence.png";
+        sscsCorBackendRequests.uploadEvidence(hearingWithQuestion.getHearingId(), hearingWithQuestion.getQuestionId(), fileName);
+
+
+        questionResponse = sscsCorBackendRequests.getQuestion(hearingWithQuestion.getHearingId(), hearingWithQuestion.getQuestionId());
+        JSONArray evidence = questionResponse.getJSONArray("evidence");
+        assertThat(evidence.length(), is(1));
+        assertThat(evidence.getJSONObject(0).getString("file_name"), is(fileName));
+
+        sscsCorBackendRequests.answerQuestion(hearingWithQuestion.getHearingId(), hearingWithQuestion.getQuestionId(), "some answer");
+        sscsCorBackendRequests.submitAnswer(hearingWithQuestion.getHearingId(), hearingWithQuestion.getQuestionId());
+        questionResponse = sscsCorBackendRequests.getQuestion(hearingWithQuestion.getHearingId(), hearingWithQuestion.getQuestionId());
+        assertThat(questionResponse.has("evidence"), is(true));
+    }
+
+    @Test
     public void uploadThenDeleteEvidenceToHearing() throws IOException, JSONException {
         OnlineHearing hearingWithQuestion = createHearing(true);
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionTest.java
@@ -8,6 +8,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someCohAnswers;
 import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.submitted;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 import org.junit.Test;
@@ -93,13 +94,17 @@ public class QuestionTest extends BaseIntegrationTest {
     }
 
     @Test
-    public void submitAnAnswerToAQuestion() {
+    public void submitAnAnswerToAQuestion() throws JsonProcessingException {
         String hearingId = "1";
         String questionId = "1";;
         String answerId = UUID.randomUUID().toString();
         String answer = "answer";
+        long caseId = 123L;
         cohStub.stubGetAnswer(hearingId, questionId, answer, answerId, "answer_drafted", ZonedDateTime.now());
         cohStub.stubUpdateAnswer(hearingId, questionId, answer, answerId, submitted);
+        cohStub.stubGetOnlineHearing(caseId, hearingId);
+        ccdStub.stubFindCaseByCaseId(caseId, "1", "someEvidence", "01-01-2010", "http://evidenceUrl");
+        ccdStub.stubUpdateCaseWithEvent(caseId, "uploadCorDocument", "caseRef");
 
         getRequest()
                 .when()

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
@@ -33,7 +33,7 @@ public class CcdStub extends BaseStub {
             "        },\n" +
             "        \"benefitType\": { \"code\": \"PIP\" }\n" +
             "      },\n" +
-            "      \"corDocument\": [\n" +
+            "      \"draftCorDocument\": [\n" +
             "        {\n" +
             "          \"value\": {\n" +
             "            \"document\": {\n" +

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadController.java
@@ -82,7 +82,7 @@ public class EvidenceUploadController {
             @PathVariable("questionId") String questionId,
             @RequestParam("file") MultipartFile file
     ) {
-        return uploadEvidence(() -> evidenceUploadService.uploadQuestionEvidence(onlineHearingId, questionId, file));
+        return uploadEvidence(() -> evidenceUploadService.uploadDraftQuestionEvidence(onlineHearingId, questionId, file));
     }
 
     private ResponseEntity<Evidence> uploadEvidence(Supplier<Optional<Evidence>> uploadEvidence) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
@@ -75,6 +75,7 @@ public class QuestionService {
                     CohUpdateAnswer updatedAnswer = new CohUpdateAnswer(AnswerState.submitted.getCohAnswerState(), answer.getAnswerText());
                     String answerId = answers.get(0).getAnswerId();
                     cohService.updateAnswer(onlineHearingId, questionId, answerId, updatedAnswer);
+                    evidenceUploadService.submitQuestionEvidence(onlineHearingId, questionId);
 
                     return true;
                 })

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadControllerTest.java
@@ -77,7 +77,7 @@ public class EvidenceUploadControllerTest {
     @Test
     public void canUploadEvidenceToQuestion() {
         MultipartFile file = mock(MultipartFile.class);
-        when(evidenceUploadService.uploadQuestionEvidence(someOnlineHearingId, someQuestionId, file)).thenReturn(of(evidence));
+        when(evidenceUploadService.uploadDraftQuestionEvidence(someOnlineHearingId, someQuestionId, file)).thenReturn(of(evidence));
 
         ResponseEntity<Evidence> evidenceResponseEntity = evidenceUploadController.uploadEvidence(
                 someOnlineHearingId, someQuestionId, file
@@ -89,7 +89,7 @@ public class EvidenceUploadControllerTest {
     @Test
     public void cannotUploadEvidenceToQuestionWhenOnlineHearingDoesNotExist() {
         MultipartFile file = mock(MultipartFile.class);
-        when(evidenceUploadService.uploadQuestionEvidence(someOnlineHearingId, someQuestionId, file)).thenReturn(empty());
+        when(evidenceUploadService.uploadDraftQuestionEvidence(someOnlineHearingId, someQuestionId, file)).thenReturn(empty());
 
         ResponseEntity<Evidence> evidenceResponseEntity = evidenceUploadController.uploadEvidence(
                 someOnlineHearingId, someQuestionId, file
@@ -101,7 +101,7 @@ public class EvidenceUploadControllerTest {
     @Test
     public void cannotUploadDocumentsToQuestionThatDocumentStoreDoesNotSupport() {
         MultipartFile file = mock(MultipartFile.class);
-        when(evidenceUploadService.uploadQuestionEvidence(someOnlineHearingId, someQuestionId, file)).thenThrow(new IllegalFileTypeException("someFile.bad"));
+        when(evidenceUploadService.uploadDraftQuestionEvidence(someOnlineHearingId, someQuestionId, file)).thenThrow(new IllegalFileTypeException("someFile.bad"));
 
         ResponseEntity<Evidence> evidenceResponseEntity = evidenceUploadController.uploadEvidence(
                 someOnlineHearingId, someQuestionId, file

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
@@ -288,6 +288,7 @@ public class QuestionServiceTest {
 
         assertThat(hasBeenSubmitted, is(true));
         verify(cohService).updateAnswer(onlineHearingId, questionId, answerId, new CohUpdateAnswer(submitted.getCohAnswerState(), answer));
+        verify(evidenceUploadService).submitQuestionEvidence(onlineHearingId, questionId);
     }
 
     @Test


### PR DESCRIPTION
When we upload evidence to a question it could be viewed in CCD before
the appellant submits the question.

We have created a draftCorDocuments field in CCD which the caseworker
does not have permission to view. As evidence is uploaded we add it to
that list. When the question is submitted we then copy the evidence
across to the corDocument field which the caseworker can view. This
should also be where JUI picks up the evidence to display to the Judge
and panel.

https://tools.hmcts.net/jira/browse/SSCS-5470

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
