### PR TITLE
SSCS-5223 Panel listing notes in CCD

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,7 +162,7 @@ dependencies {
   compileOnly 'org.projectlombok:lombok:1.18.6'
   compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.2.4.RELEASE'
   compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
-  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '2.0.1'
+  compile group: 'uk.gov.hmcts.reform', name:'sscs-common', version: '2.0.5'
 
   compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.0.3'
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '5.0.0'

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohEventsTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/CohEventsTests.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.sscscorbackend;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import java.io.IOException;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+
+public class CohEventsTests extends BaseFunctionTest {
+    @Test
+    public void relistingHearingUpdatesCcd() throws IOException, InterruptedException {
+        OnlineHearing onlineHearing = createHearingWithQuestion(true);
+
+        answerQuestion(onlineHearing.getHearingId(), onlineHearing.getQuestionId());
+
+        String relistingReason = "some relisting reason";
+        cohRequests.setRelistingReason(onlineHearing.getHearingId(), relistingReason);
+
+        SscsCaseDetails caseDetails = getCaseDetails(onlineHearing.getCaseId());
+
+        assertThat(caseDetails.getData().getRelistingReason(), is(nullValue()));
+        assertThat(caseDetails.getData().getAppeal().getHearingType(), is("cor"));
+
+        //now trigger our endpoint
+        relistHearing(onlineHearing.getHearingId(), onlineHearing.getCaseId());
+        waitForCcdEvent(onlineHearing.getCaseId(), EventType.COH_ONLINE_HEARING_RELISTED);
+
+        caseDetails = getCaseDetails(onlineHearing.getCaseId());
+
+        assertThat(caseDetails.getData().getRelistingReason(), is(relistingReason));
+        assertThat(caseDetails.getData().getAppeal().getHearingType(), is("oral"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -67,8 +67,8 @@ public class DataFixtures {
 
     public static CohQuestionRounds someCohQuestionRoundsWithSingleRoundOfQuestions() {
         List<CohQuestionReference> cohQuestionReferenceList = Arrays.asList(
-                new CohQuestionReference("someQuestionId1", 1, "first question", "first question body",  now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted")),
-                new CohQuestionReference("someQuestionId2", 2, "second question", "second question body",  now().plusDays(10).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))
+                new CohQuestionReference("someQuestionId1", 1, "first question", "first question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted")),
+                new CohQuestionReference("someQuestionId2", 2, "second question", "second question body", now().plusDays(10).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))
         );
         return new CohQuestionRounds(1, singletonList(new CohQuestionRound(cohQuestionReferenceList, 0, someCohState("question_issued"))));
     }
@@ -82,7 +82,7 @@ public class DataFixtures {
                 new CohQuestionRound(singletonList(
                         new CohQuestionReference("someQuestionId", 1, "first round question", "first question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))), 0, someCohState("question_issued")),
                 new CohQuestionRound(singletonList(
-                        new CohQuestionReference("someOtherQuestionId", 1, "second round question","second question body",  now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))), 0, someCohState("question_issued"))
+                        new CohQuestionReference("someOtherQuestionId", 1, "second round question", "second question body", now().plusDays(7).format(ISO_LOCAL_DATE_TIME), someCohAnswers("answer_drafted"))), 0, someCohState("question_issued"))
         ));
     }
 
@@ -174,5 +174,14 @@ public class DataFixtures {
 
     public static Statement someStatement() {
         return new Statement("Some Statement body");
+    }
+
+    public static CohConversations someCohConversations(String relistingReason) {
+        return new CohConversations(
+                new CohConversation(
+                        singletonList(someCohQuestion()),
+                        new CohRelisting(relistingReason)
+                )
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/api/CcdHistoryEventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/ccd/api/CcdHistoryEventTest.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+
+public class CcdHistoryEventTest {
+    @Test
+    public void canGetEventTypeFromCcdEventType() {
+        CcdHistoryEvent ccdHistoryEvent = new CcdHistoryEvent(
+                EventType.COH_ONLINE_HEARING_RELISTED.getCcdType()
+        );
+
+        assertThat(ccdHistoryEvent.getEventType(), is(EventType.COH_ONLINE_HEARING_RELISTED));
+    }
+
+}


### PR DESCRIPTION
As a tribunal case worker I want to see the panel's listing notes in CCD
so that I know if specific arrangements need to be made.

When cor-backend receives a continuous_online_hearing_relisted event
from COH we need to get the relisting reason from the COH conversation
and save it to CCD in the relistingReason field. This will then be
displayed in the CCD UI on the online hearing tab.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-5223

**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[X] No
```
