### PR TITLE
Fix issuing questions was failing when the PDF failed to create

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '5.0.0'
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '5.0.1'
   compile group: 'uk.gov.hmcts.reform.auth', name: 'auth-checker-lib', version: '2.1.3'
+  compile group: 'org.jsoup', name: 'jsoup', version: '1.11.3'
   
   // Removed for now as we have an issue with some of its dependencies
   // compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix-dashboard', version: versions.springHystrix

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/AbstractQuestionPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/AbstractQuestionPdfService.java
@@ -1,18 +1,22 @@
 package uk.gov.hmcts.reform.sscscorbackend.service.pdf;
 
+import java.util.List;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.CcdPdfService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionSummary;
 import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfQuestionsSummary;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.QuestionUtils;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 public abstract class AbstractQuestionPdfService extends StorePdfService<PdfQuestionsSummary, PdfData> {
     private final QuestionService questionService;
+    private final QuestionUtils questionUtils;
 
     @SuppressWarnings("squid:S00107")
     public AbstractQuestionPdfService(
@@ -21,9 +25,11 @@ public abstract class AbstractQuestionPdfService extends StorePdfService<PdfQues
             CcdPdfService ccdPdfService,
             IdamService idamService,
             QuestionService questionService,
-            EvidenceManagementService evidenceManagementService) {
+            EvidenceManagementService evidenceManagementService,
+            QuestionUtils questionUtils) {
         super(pdfService, templatePath, ccdPdfService, idamService, evidenceManagementService);
         this.questionService = questionService;
+        this.questionUtils = questionUtils;
     }
 
     @Override
@@ -37,6 +43,7 @@ public abstract class AbstractQuestionPdfService extends StorePdfService<PdfQues
     @Override
     protected PdfQuestionsSummary getPdfContent(PdfData data, String onlineHearingId, PdfAppealDetails appealDetails) {
         QuestionRound questions = questionService.getQuestions(onlineHearingId, false);
-        return new PdfQuestionsSummary(appealDetails, questions.getQuestions());
+        List<QuestionSummary> questionSummaries = questionUtils.cleanUpQuestionsHtml(questions.getQuestions());
+        return new PdfQuestionsSummary(appealDetails, questionSummaries);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreAnswersDeadlineElapsedPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreAnswersDeadlineElapsedPdfService.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.CcdPdfService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.QuestionUtils;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 @Service
@@ -20,8 +21,9 @@ public class StoreAnswersDeadlineElapsedPdfService extends AbstractQuestionPdfSe
             CcdPdfService ccdPdfService,
             IdamService idamService,
             QuestionService questionService,
-            EvidenceManagementService evidenceManagementService) {
-        super(pdfService, templatePath, ccdPdfService, idamService, questionService, evidenceManagementService);
+            EvidenceManagementService evidenceManagementService,
+            QuestionUtils questionUtils) {
+        super(pdfService, templatePath, ccdPdfService, idamService, questionService, evidenceManagementService, questionUtils);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreAnswersPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreAnswersPdfService.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.CcdPdfService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.QuestionUtils;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 @Service
@@ -20,8 +21,10 @@ public class StoreAnswersPdfService extends AbstractQuestionPdfService {
             CcdPdfService ccdPdfService,
             IdamService idamService,
             QuestionService questionService,
-            EvidenceManagementService evidenceManagementService) {
-        super(pdfService, templatePath, ccdPdfService, idamService, questionService, evidenceManagementService);
+            EvidenceManagementService evidenceManagementService,
+            QuestionUtils questionUtils
+    ) {
+        super(pdfService, templatePath, ccdPdfService, idamService, questionService, evidenceManagementService, questionUtils);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreQuestionsPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreQuestionsPdfService.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.service.CcdPdfService;
 import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.QuestionUtils;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 @Service
@@ -20,8 +21,10 @@ public class StoreQuestionsPdfService extends AbstractQuestionPdfService {
             CcdPdfService ccdPdfService,
             IdamService idamService,
             QuestionService questionService,
-            EvidenceManagementService evidenceManagementService) {
-        super(pdfService, templatePath, ccdPdfService, idamService, questionService, evidenceManagementService);
+            EvidenceManagementService evidenceManagementService,
+            QuestionUtils questionUtils
+    ) {
+        super(pdfService, templatePath, ccdPdfService, idamService, questionService, evidenceManagementService, questionUtils);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/util/QuestionUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/util/QuestionUtils.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.sscscorbackend.service.pdf.util;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionSummary;
+
+@Component
+public class QuestionUtils {
+    public List<QuestionSummary> cleanUpQuestionsHtml(List<QuestionSummary> questions) {
+        return questions.stream().map(questionSummary -> new QuestionSummary(
+                questionSummary.getId(),
+                questionSummary.getQuestionOrdinal(),
+                questionSummary.getQuestionHeaderText(),
+                getXhtmlFromHtml(questionSummary.getQuestionBodyText()),
+                questionSummary.getAnswerState(),
+                questionSummary.getAnswer())
+        ).collect(toList());
+    }
+
+    private String getXhtmlFromHtml(String inputHtml) {
+        final Document document = Jsoup.parse("<wrapperTag>" + inputHtml + "</wrapperTag>");
+        document.outputSettings().syntax(Document.OutputSettings.Syntax.xml);
+        return document.selectFirst("wrapperTag").html();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreAnswersDeadlineElapsedPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreAnswersDeadlineElapsedPdfServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfQuestionsSummary;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.QuestionUtils;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 
 public class StoreAnswersDeadlineElapsedPdfServiceTest {
@@ -24,19 +25,22 @@ public class StoreAnswersDeadlineElapsedPdfServiceTest {
     private QuestionService questionService;
     private String onlineHearingId;
     private StoreAnswersDeadlineElapsedPdfService storeQuestionsPdfService;
+    private QuestionUtils questionUtils;
 
     @Before
     public void setUp() {
         questionService = mock(QuestionService.class);
         onlineHearingId = "someOnlineHearingId";
+        questionUtils = mock(QuestionUtils.class);
         storeQuestionsPdfService = new StoreAnswersDeadlineElapsedPdfService(
                 mock(OldPdfService.class), "sometemplate", mock(CcdPdfService.class), mock(IdamService.class),
-                questionService, mock(EvidenceManagementService.class));
+                questionService, mock(EvidenceManagementService.class), questionUtils);
     }
 
     @Test
     public void getPdfQuestionSummary() {
         QuestionRound questionRound = DataFixtures.someQuestionRound();
+        when(questionUtils.cleanUpQuestionsHtml(questionRound.getQuestions())).thenReturn(questionRound.getQuestions());
         when(questionService.getQuestions(onlineHearingId, false)).thenReturn(questionRound);
         PdfAppealDetails appealDetails = mock(PdfAppealDetails.class);
         PdfQuestionsSummary pdfQuestionsSummary = storeQuestionsPdfService.getPdfContent(mock(PdfData.class), onlineHearingId, appealDetails);

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreAnswersPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreAnswersPdfServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfQuestionsSummary;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.QuestionUtils;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 
 public class StoreAnswersPdfServiceTest {
@@ -24,19 +25,22 @@ public class StoreAnswersPdfServiceTest {
     private QuestionService questionService;
     private String onlineHearingId;
     private StoreAnswersPdfService storeQuestionsPdfService;
+    private QuestionUtils questionUtils;
 
     @Before
     public void setUp() {
         questionService = mock(QuestionService.class);
         onlineHearingId = "someOnlineHearingId";
+        questionUtils = mock(QuestionUtils.class);
         storeQuestionsPdfService = new StoreAnswersPdfService(
                 mock(OldPdfService.class), "sometemplate", mock(CcdPdfService.class), mock(IdamService.class),
-                questionService, mock(EvidenceManagementService.class));
+                questionService, mock(EvidenceManagementService.class), questionUtils);
     }
 
     @Test
     public void getPdfQuestionSummary() {
         QuestionRound questionRound = DataFixtures.someQuestionRound();
+        when(questionUtils.cleanUpQuestionsHtml(questionRound.getQuestions())).thenReturn(questionRound.getQuestions());
         when(questionService.getQuestions(onlineHearingId, false)).thenReturn(questionRound);
         PdfAppealDetails appealDetails = mock(PdfAppealDetails.class);
         PdfQuestionsSummary pdfQuestionsSummary = storeQuestionsPdfService.getPdfContent(mock(PdfData.class), onlineHearingId, appealDetails);

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreQuestionsPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/StoreQuestionsPdfServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.pdf.PdfAppealDetails;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfQuestionsSummary;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.QuestionUtils;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.OldPdfService;
 
 public class StoreQuestionsPdfServiceTest {
@@ -24,14 +25,16 @@ public class StoreQuestionsPdfServiceTest {
     private QuestionService questionService;
     private String onlineHearingId;
     private StoreQuestionsPdfService storeQuestionsPdfService;
+    private QuestionUtils questionUtils;
 
     @Before
     public void setUp() {
         questionService = mock(QuestionService.class);
         onlineHearingId = "someOnlineHearingId";
+        questionUtils = mock(QuestionUtils.class);
         storeQuestionsPdfService = new StoreQuestionsPdfService(
                 mock(OldPdfService.class), "sometemplate", mock(CcdPdfService.class), mock(IdamService.class),
-                questionService, mock(EvidenceManagementService.class));
+                questionService, mock(EvidenceManagementService.class), questionUtils);
     }
 
     @Test
@@ -39,6 +42,8 @@ public class StoreQuestionsPdfServiceTest {
         QuestionRound questionRound = DataFixtures.someQuestionRound();
         when(questionService.getQuestions(onlineHearingId, false)).thenReturn(questionRound);
         PdfAppealDetails appealDetails = mock(PdfAppealDetails.class);
+        when(questionUtils.cleanUpQuestionsHtml(questionRound.getQuestions())).thenReturn(questionRound.getQuestions());
+
         PdfQuestionsSummary pdfQuestionsSummary = storeQuestionsPdfService.getPdfContent(mock(PdfData.class), onlineHearingId, appealDetails);
 
         assertThat(pdfQuestionsSummary, is(new PdfQuestionsSummary(appealDetails, questionRound.getQuestions())));

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/util/QuestionUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/util/QuestionUtilsTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.sscscorbackend.service.pdf.util;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionSummary;
+
+public class QuestionUtilsTest {
+    @Test
+    public void doesNotCleanNoneHtml() {
+        String plainTextQuestion = "plain text body";
+        List<QuestionSummary> originalQuestions = singletonList(
+                new QuestionSummary("id", 1, "header", plainTextQuestion, AnswerState.submitted, "some answer")
+        );
+        List<QuestionSummary> cleanedQuestions = new QuestionUtils().cleanUpQuestionsHtml(originalQuestions);
+
+        assertThat(cleanedQuestions, is(originalQuestions));
+    }
+
+    @Test
+    public void cleansNoneXhtml() {
+        String htmlQuestion = "<p><br></p>";
+        List<QuestionSummary> originalQuestions = singletonList(
+                new QuestionSummary("id", 1, "header", htmlQuestion, AnswerState.submitted, "some answer")
+        );
+        List<QuestionSummary> cleanedQuestions = new QuestionUtils().cleanUpQuestionsHtml(originalQuestions);
+
+        assertThat(cleanedQuestions.size(), is(1));
+        assertThat(cleanedQuestions.get(0).getQuestionBodyText(), is("<p><br /></p>"));
+    }
+
+    @Test
+    public void doesNotChangeValidXhtml() {
+        String htmlQuestion = "<p>This is valid content</p>";
+        List<QuestionSummary> originalQuestions = singletonList(
+                new QuestionSummary("id", 1, "header", htmlQuestion, AnswerState.submitted, "some answer")
+        );
+        List<QuestionSummary> cleanedQuestions = new QuestionUtils().cleanUpQuestionsHtml(originalQuestions);
+
+        assertThat(cleanedQuestions.size(), is(1));
+        assertThat(cleanedQuestions.get(0).getQuestionBodyText(), is(htmlQuestion));
+    }
+
+    @Test
+    public void canHandleNbsp() {
+        String htmlQuestion = "<p>This is valid content&nbsp;</p>";
+        List<QuestionSummary> originalQuestions = singletonList(
+                new QuestionSummary("id", 1, "header", htmlQuestion, AnswerState.submitted, "some answer")
+        );
+        List<QuestionSummary> cleanedQuestions = new QuestionUtils().cleanUpQuestionsHtml(originalQuestions);
+
+        assertThat(cleanedQuestions.size(), is(1));
+        assertThat(cleanedQuestions.get(0).getQuestionBodyText(), is(htmlQuestion));
+    }
+
+    @Test
+    public void canHandleMultipleTags() {
+        String htmlQuestion = "<p>This is valid content&nbsp;</p><p><br></p>";
+        List<QuestionSummary> originalQuestions = singletonList(
+                new QuestionSummary("id", 1, "header", htmlQuestion, AnswerState.submitted, "some answer")
+        );
+        List<QuestionSummary> cleanedQuestions = new QuestionUtils().cleanUpQuestionsHtml(originalQuestions);
+
+        assertThat(cleanedQuestions.size(), is(1));
+        assertThat(cleanedQuestions.get(0).getQuestionBodyText(), is("<p>This is valid content&nbsp;</p>\n<p><br /></p>"));
+    }
+}


### PR DESCRIPTION
This was because the question which are added to the pdf were not xhtml.
The pdf service cannot handle this. Added code to transform the question
to xhtml before it is sent to the pdf service.
