### PR TITLE
Fix issuing questions was failing when questions contained &nbsp;

### DIFF
--- a/src/main/resources/templates/answers.html
+++ b/src/main/resources/templates/answers.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />

--- a/src/main/resources/templates/evidenceDescription.html
+++ b/src/main/resources/templates/evidenceDescription.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />

--- a/src/main/resources/templates/onlineHearingSummary.html
+++ b/src/main/resources/templates/onlineHearingSummary.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />

--- a/src/main/resources/templates/personalStatement.html
+++ b/src/main/resources/templates/personalStatement.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />

--- a/src/main/resources/templates/questions.html
+++ b/src/main/resources/templates/questions.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />

--- a/src/main/resources/templates/tribunalsView.html
+++ b/src/main/resources/templates/tribunalsView.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />


### PR DESCRIPTION
In XHTML `&nbsp;` is not valid unless you use a doctype that knows
about it. We should have been setting doctypes anyway so setting all
pdf templates to use `<!DOCTYPE html>`