### PR TITLE
SSCS-5566 Answers pdf not getting updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,7 +229,8 @@ sonarqube {
                 "src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java," +
                 "src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/EvidenceDescriptionPdfData.java," +
                 "src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/pdf/PdfEvidenceDescription.java," +
-                "src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/PdfCoverSheet.java"
+                "src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/PdfCoverSheet.java," +
+                "src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/data/PdfData.java"
     }
 }
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/TriggerCohEventsTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/TriggerCohEventsTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 
-public class CohEventsTests extends BaseFunctionTest {
+public class TriggerCohEventsTest extends BaseFunctionTest {
     @Test
     public void relistingHearingUpdatesCcd() throws IOException, InterruptedException {
         OnlineHearing onlineHearing = createHearingWithQuestion(true);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohEventsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/CohEventsTest.java
@@ -79,7 +79,7 @@ public class CohEventsTest extends BaseIntegrationTest {
     public void answerSubmittedCohEvent() throws IOException {
         ccdStub.stubFindCaseByCaseId(caseId, caseReference, "first-id", "someEvidence", "evidenceCreatedDate", "http://example.com/document/1");
         CohQuestionReference questionSummary = new CohQuestionReference(
-                "first-id", 1, "first question", "first question body", "2018-01-01", someCohAnswers("answer_drafted")
+                "first-id", 1, "first question", "first question body", "2018-01-01", someCohAnswers("answer_submitted")
         );
         cohStub.stubGetAllQuestionRounds(hearingId, questionSummary);
         cohStub.stubGetOnlineHearing(caseId, hearingId);

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/CohEventActionRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/CohEventActionRunner.java
@@ -30,10 +30,8 @@ public class CohEventActionRunner {
         Long caseId = Long.valueOf(event.getCaseId());
 
         SscsCaseDetails sscsCaseDetails = loadCcdCaseDetails(caseId);
-        log.info("Storing pdf [" + caseId + "]");
-        CohEventActionContext storePdfResultStorePdf = cohEventAction.createAndStorePdf(caseId, onlineHearingId, sscsCaseDetails);
-        log.info("Handle coh event [" + caseId + "]");
-        CohEventActionContext cohEventActionContextHandle = cohEventAction.handle(caseId, onlineHearingId, storePdfResultStorePdf);
+        log.info("Storing and handle pdf [" + caseId + "]");
+        CohEventActionContext cohEventActionContextHandle = cohEventAction.handle(caseId, onlineHearingId, sscsCaseDetails);
         log.info("Notify appellant [" + caseId + "]");
 
         if (cohEventAction.notifyAppellant()) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/AnswerSubmittedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/AnswerSubmittedEventAction.java
@@ -1,20 +1,37 @@
 package uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions;
 
+import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.submitted;
+
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
+import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreAnswersPdfService;
 
 @Service
 public class AnswerSubmittedEventAction extends QuestionRoundEndedAction {
 
-    public AnswerSubmittedEventAction(CorEmailService corEmailService, StoreAnswersPdfService storeAnswersPdfService, EmailMessageBuilder emailMessageBuilder) {
+    private final QuestionService questionService;
+
+    public AnswerSubmittedEventAction(CorEmailService corEmailService, StoreAnswersPdfService storeAnswersPdfService, EmailMessageBuilder emailMessageBuilder, QuestionService questionService) {
         super(storeAnswersPdfService, corEmailService, emailMessageBuilder);
+        this.questionService = questionService;
     }
 
-    protected String getDwpEmailSubject(String caseReference) {
-        return "Appellant has provided information (" + caseReference + ")";
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, SscsCaseDetails sscsCaseDetails) {
+        QuestionRound questions = questionService.getQuestions(onlineHearingId, true);
+
+        boolean questionRoundAnswered = questions.getQuestions().stream()
+                .allMatch(questionSummary -> submitted.equals(questionSummary.getAnswerState()));
+
+        if (questionRoundAnswered) {
+            return super.handle(caseId, onlineHearingId, sscsCaseDetails);
+        }
+        return new CohEventActionContext(null, sscsCaseDetails);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/CohEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/CohEventAction.java
@@ -7,11 +7,9 @@ import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 public interface CohEventAction {
     String cohEvent();
 
-    default CohEventActionContext createAndStorePdf(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
+    default CohEventActionContext handle(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
         return new CohEventActionContext(null, caseDetails);
     }
-
-    CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext);
 
     EventType getCcdEventType();
 

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineElapsedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineElapsedEventAction.java
@@ -19,11 +19,6 @@ public class DeadlineElapsedEventAction extends QuestionRoundEndedAction {
     }
 
     @Override
-    protected String getDwpEmailSubject(String caseReference) {
-        return "Appellant has provided information (" + caseReference + ")";
-    }
-
-    @Override
     public String cohEvent() {
         return "question_deadline_elapsed";
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineExtendedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineExtendedEventAction.java
@@ -2,18 +2,13 @@ package uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 @Service
 public class DeadlineExtendedEventAction implements CohEventAction {
+
     @Override
     public String cohEvent() {
         return "question_deadline_extended";
-    }
-
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        return cohEventActionContext;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineExtensionDeniedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineExtensionDeniedEventAction.java
@@ -2,18 +2,12 @@ package uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 @Service
 public class DeadlineExtensionDeniedEventAction implements CohEventAction {
     @Override
     public String cohEvent() {
         return "question_deadline_extension_denied";
-    }
-
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        return cohEventActionContext;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineExtensionGrantedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineExtensionGrantedEventAction.java
@@ -2,18 +2,12 @@ package uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 @Service
 public class DeadlineExtensionGrantedEventAction implements CohEventAction {
     @Override
     public String cohEvent() {
         return "question_deadline_extension_granted";
-    }
-
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        return cohEventActionContext;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineReminderEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineReminderEventAction.java
@@ -2,18 +2,12 @@ package uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 @Service
 public class DeadlineReminderEventAction implements CohEventAction {
     @Override
     public String cohEvent() {
         return "question_deadline_reminder";
-    }
-
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        return cohEventActionContext;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DecisionIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DecisionIssuedEventAction.java
@@ -22,20 +22,16 @@ public class DecisionIssuedEventAction implements CohEventAction {
     }
 
     @Override
-    public CohEventActionContext createAndStorePdf(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
-        return storeOnlineHearingTribunalsViewService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails));
-    }
-
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        String caseReference = cohEventActionContext.getDocument().getData().getCaseReference();
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
+        CohEventActionContext actionContext = storeOnlineHearingTribunalsViewService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails));
+        String caseReference = actionContext.getDocument().getData().getCaseReference();
         emailService.sendFileToDwp(
-                cohEventActionContext,
+                actionContext,
                 "Preliminary view offered (" + caseReference + ")",
-                emailMessageBuilder.getDecisionIssuedMessage(cohEventActionContext.getDocument())
+                emailMessageBuilder.getDecisionIssuedMessage(actionContext.getDocument())
         );
 
-        return cohEventActionContext;
+        return actionContext;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DecisionRejectedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DecisionRejectedEventAction.java
@@ -2,18 +2,12 @@ package uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 
 @Service
 public class DecisionRejectedEventAction implements CohEventAction {
     @Override
     public String cohEvent() {
         return "decision_rejected";
-    }
-
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        return cohEventActionContext;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/HearingRelistedAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/HearingRelistedAction.java
@@ -38,19 +38,14 @@ public class HearingRelistedAction implements CohEventAction {
         this.cohService = cohService;
     }
 
-    @Override
-    public CohEventActionContext createAndStorePdf(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
-        return storeOnlineHearingService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails));
-    }
-
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        SscsCaseData oralSscsCaseData = updateCcdCaseToOralHearing(caseId, onlineHearingId, cohEventActionContext);
-        String relistedMessage = emailMessageBuilder.getRelistedMessage(cohEventActionContext.getDocument());
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
+        CohEventActionContext actionContext = storeOnlineHearingService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails));
+        SscsCaseData oralSscsCaseData = updateCcdCaseToOralHearing(caseId, onlineHearingId, actionContext);
+        String relistedMessage = emailMessageBuilder.getRelistedMessage(actionContext.getDocument());
         corEmailService.sendEmailToDwp("COR: Hearing required", relistedMessage);
 
-        SscsCaseDetails oralSscsCaseDetails = cohEventActionContext.getDocument().toBuilder().data(oralSscsCaseData).build();
-        return new CohEventActionContext(cohEventActionContext.getPdf(), oralSscsCaseDetails);
+        SscsCaseDetails oralSscsCaseDetails = actionContext.getDocument().toBuilder().data(oralSscsCaseData).build();
+        return new CohEventActionContext(actionContext.getPdf(), oralSscsCaseDetails);
     }
 
     private SscsCaseData updateCcdCaseToOralHearing(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/QuestionRoundEndedAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/QuestionRoundEndedAction.java
@@ -19,22 +19,20 @@ public abstract class QuestionRoundEndedAction implements CohEventAction {
     }
 
     @Override
-    public CohEventActionContext createAndStorePdf(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
-        return storePdfService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails));
-    }
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, SscsCaseDetails sscsCaseDetails) {
+        CohEventActionContext actionContext = storePdfService.storePdf(caseId, onlineHearingId, new PdfData(sscsCaseDetails));
 
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        SscsCaseDetails sscsCaseDetails = cohEventActionContext.getDocument();
         String caseReference = sscsCaseDetails.getData().getCaseReference();
         corEmailService.sendFileToDwp(
-                cohEventActionContext,
+                actionContext,
                 getDwpEmailSubject(caseReference),
                 emailMessageBuilder.getAnswerMessage(sscsCaseDetails)
         );
 
-        return cohEventActionContext;
+        return actionContext;
     }
 
-    protected abstract String getDwpEmailSubject(String caseReference);
+    protected String getDwpEmailSubject(String caseReference) {
+        return "Appellant has provided information (" + caseReference + ")";
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/QuestionRoundIssuedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/QuestionRoundIssuedEventAction.java
@@ -24,17 +24,12 @@ public class QuestionRoundIssuedEventAction implements CohEventAction {
         this.emailMessageBuilder = emailMessageBuilder;
     }
 
-    @Override
-    public CohEventActionContext createAndStorePdf(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
-        return storeQuestionsPdfService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails));
-    }
+    public CohEventActionContext handle(Long caseId, String onlineHearingId, SscsCaseDetails caseDetails) {
+        CohEventActionContext actionContext = storeQuestionsPdfService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails));
+        SscsCaseDetails sscsCaseDetails = actionContext.getDocument();
+        sendDwpEmail(actionContext, sscsCaseDetails);
 
-    @Override
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, CohEventActionContext cohEventActionContext) {
-        SscsCaseDetails sscsCaseDetails = cohEventActionContext.getDocument();
-        sendDwpEmail(cohEventActionContext, sscsCaseDetails);
-
-        return cohEventActionContext;
+        return actionContext;
     }
 
     public StorePdfService getPdfService() {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/data/PdfData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/data/PdfData.java
@@ -12,4 +12,23 @@ public class PdfData {
     public SscsCaseDetails getCaseDetails() {
         return caseDetails;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PdfData pdfData = (PdfData) o;
+
+        return caseDetails != null ? caseDetails.equals(pdfData.caseDetails) : pdfData.caseDetails == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return caseDetails != null ? caseDetails.hashCode() : 0;
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/CohEventActionRunnerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/CohEventActionRunnerTest.java
@@ -23,7 +23,6 @@ public class CohEventActionRunnerTest {
     private CohEventAction cohEventAction;
     private String hearingId;
     private CohEvent cohEvent;
-    private CohEventActionContext cohEventActionContext;
     private Long caseIdLong;
     private CohEventActionRunner cohEventActionRunner;
     private CorCcdService corCcdService;
@@ -39,18 +38,14 @@ public class CohEventActionRunnerTest {
         String caseId = "123456";
         hearingId = "hearingId";
         cohEvent = someCohEvent(caseId, hearingId, "some-event");
-
-        cohEventActionContext = mock(CohEventActionContext.class);
         caseIdLong = valueOf(caseId);
-
         CohEventActionContext cohEventActionContextHandle = mock(CohEventActionContext.class);
         sscsCaseData = SscsCaseData.builder().build();
         sscsCaseDetails = SscsCaseDetails.builder()
                 .data(sscsCaseData)
                 .build();
         when(cohEventActionContextHandle.getDocument()).thenReturn(sscsCaseDetails);
-        when(cohEventAction.createAndStorePdf(caseIdLong, hearingId, sscsCaseDetails)).thenReturn(cohEventActionContext);
-        when(cohEventAction.handle(caseIdLong, hearingId, cohEventActionContext)).thenReturn(cohEventActionContextHandle);
+        when(cohEventAction.handle(caseIdLong, hearingId, sscsCaseDetails)).thenReturn(cohEventActionContextHandle);
         ccdEvent = EventType.COH_ANSWERS_SUBMITTED;
         when(cohEventAction.getCcdEventType()).thenReturn(ccdEvent);
 
@@ -69,8 +64,7 @@ public class CohEventActionRunnerTest {
 
         cohEventActionRunner.runActionSync(cohEvent, cohEventAction);
 
-        verify(cohEventAction).createAndStorePdf(caseIdLong, hearingId, sscsCaseDetails);
-        verify(cohEventAction).handle(caseIdLong, hearingId, cohEventActionContext);
+        verify(cohEventAction).handle(caseIdLong, hearingId, sscsCaseDetails);
         verify(notificationService).send(cohEvent);
         verify(corCcdService).updateCase(sscsCaseData,
                 caseIdLong,
@@ -86,8 +80,7 @@ public class CohEventActionRunnerTest {
 
         cohEventActionRunner.runActionSync(cohEvent, cohEventAction);
 
-        verify(cohEventAction).createAndStorePdf(caseIdLong, hearingId, sscsCaseDetails);
-        verify(cohEventAction).handle(caseIdLong, hearingId, cohEventActionContext);
+        verify(cohEventAction).handle(caseIdLong, hearingId, sscsCaseDetails);
         verifyZeroInteractions(notificationService);
         verify(corCcdService).updateCase(sscsCaseData,
                 caseIdLong,
@@ -103,8 +96,7 @@ public class CohEventActionRunnerTest {
 
         cohEventActionRunner.runActionAsync(cohEvent, cohEventAction);
 
-        verify(cohEventAction).createAndStorePdf(caseIdLong, hearingId, sscsCaseDetails);
-        verify(cohEventAction).handle(caseIdLong, hearingId, cohEventActionContext);
+        verify(cohEventAction).handle(caseIdLong, hearingId, sscsCaseDetails);
         verify(notificationService).send(cohEvent);
         verify(corCcdService).updateCase(sscsCaseData,
                 caseIdLong,
@@ -120,8 +112,7 @@ public class CohEventActionRunnerTest {
 
         cohEventActionRunner.runActionAsync(cohEvent, cohEventAction);
 
-        verify(cohEventAction).createAndStorePdf(caseIdLong, hearingId, sscsCaseDetails);
-        verify(cohEventAction).handle(caseIdLong, hearingId, cohEventActionContext);
+        verify(cohEventAction).handle(caseIdLong, hearingId, sscsCaseDetails);
         verifyZeroInteractions(notificationService);
         verify(corCcdService).updateCase(sscsCaseData,
                 caseIdLong,

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/AnswerSubmittedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/AnswerSubmittedEventActionTest.java
@@ -1,41 +1,100 @@
 package uk.gov.hmcts.reform.sscscorbackend.coheventmapper.action;
 
+import static java.time.LocalDateTime.now;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.draft;
+import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.submitted;
 import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.UploadedEvidence.pdf;
 
+import java.util.List;
+import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions.AnswerSubmittedEventAction;
+import uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionSummary;
+import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreAnswersPdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
 
 public class AnswerSubmittedEventActionTest {
-    @Test
-    public void canSendPdf() {
-        CorEmailService corEmailService = mock(CorEmailService.class);
-        StoreAnswersPdfService storeAnswersPdfService = mock(StoreAnswersPdfService.class);
-        EmailMessageBuilder emailMessageBuilder = mock(EmailMessageBuilder.class);
 
-        AnswerSubmittedEventAction answerSubmittedEventAction = new AnswerSubmittedEventAction(corEmailService, storeAnswersPdfService, emailMessageBuilder);
+    private CorEmailService corEmailService;
+    private StoreAnswersPdfService storeAnswersPdfService;
+    private EmailMessageBuilder emailMessageBuilder;
+    private AnswerSubmittedEventAction answerSubmittedEventAction;
+    private long caseId;
+    private String onlineHearingId;
+    private SscsCaseDetails caseDetails;
+    private String someCaseReference;
+    private QuestionService questionService;
 
-        String someCaseReference = "someCaseReference";
-        SscsCaseDetails caseDetails = SscsCaseDetails.builder()
+    @Before
+    public void setUp() throws Exception {
+        corEmailService = mock(CorEmailService.class);
+        storeAnswersPdfService = mock(StoreAnswersPdfService.class);
+        emailMessageBuilder = mock(EmailMessageBuilder.class);
+        questionService = mock(QuestionService.class);
+
+        answerSubmittedEventAction = new AnswerSubmittedEventAction(corEmailService, storeAnswersPdfService, emailMessageBuilder, questionService);
+        caseId = 123L;
+        onlineHearingId = "onlineHearingId";
+
+        someCaseReference = "someCaseReference";
+        caseDetails = SscsCaseDetails.builder()
                 .data(SscsCaseData.builder().caseReference(someCaseReference).build())
                 .build();
-        long caseId = 123L;
-        String onlineHearingId = "onlineHearingId";
+    }
+
+    @Test
+    public void canSendPdf() {
+        QuestionRound questionRoundWithAllQuestionsAnswered = getQuestionRound(submitted);
+        when(questionService.getQuestions(onlineHearingId, true)).thenReturn(questionRoundWithAllQuestionsAnswered);
+
         String pdfName = "pdf_name.pdf";
         CohEventActionContext cohEventActionContext = new CohEventActionContext(pdf(new byte[]{2, 5, 6, 0, 1}, pdfName), caseDetails);
         when(emailMessageBuilder.getAnswerMessage(caseDetails)).thenReturn("some message");
+        when(storeAnswersPdfService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails)))
+                .thenReturn(cohEventActionContext);
 
-        CohEventActionContext result = answerSubmittedEventAction.handle(caseId, onlineHearingId, cohEventActionContext);
+        CohEventActionContext result = answerSubmittedEventAction.handle(caseId, onlineHearingId, caseDetails);
 
         verify(corEmailService).sendFileToDwp(cohEventActionContext, "Appellant has provided information (" + someCaseReference + ")", "some message");
         assertThat(result, is(cohEventActionContext));
+    }
+
+    @Test
+    public void createsPdfIfAllQuestionsAnswered() {
+        QuestionRound questionRoundWithAllQuestionsAnswered = getQuestionRound(submitted);
+        when(questionService.getQuestions(onlineHearingId, true)).thenReturn(questionRoundWithAllQuestionsAnswered);
+
+        answerSubmittedEventAction.handle(caseId, onlineHearingId, caseDetails);
+
+        verify(storeAnswersPdfService).storePdf(eq(caseId), eq(onlineHearingId), any(PdfData.class));
+    }
+
+    @Test
+    public void doesNotCreatePdfIfNotAllQuestionsAnswered() {
+        QuestionRound questionRoundWithSomeUnansweredQuestions = getQuestionRound(draft);
+        when(questionService.getQuestions(onlineHearingId, true)).thenReturn(questionRoundWithSomeUnansweredQuestions);
+        answerSubmittedEventAction.handle(caseId, onlineHearingId, caseDetails);
+
+        verifyZeroInteractions(storeAnswersPdfService);
+    }
+
+    private QuestionRound getQuestionRound(AnswerState answerState) {
+        List<QuestionSummary> questionSummaries =
+                asList(new QuestionSummary("someQuestionId", 1, "someQuestionHeader", "someQuestionBody", submitted, "someAnswer"),
+                        new QuestionSummary("someQuestionId", 2, "someQuestionHeader", "someQuestionBody", answerState, "someAnswer"));
+        return new QuestionRound(questionSummaries, now().plusDays(7).format(ISO_LOCAL_DATE_TIME), 0);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/DeadlineElapsedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/DeadlineElapsedEventActionTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreAnswersDeadlineElapsedPdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
 
 public class DeadlineElapsedEventActionTest {
     @Test
@@ -32,8 +33,10 @@ public class DeadlineElapsedEventActionTest {
         String pdfName = "pdf_name.pdf";
         CohEventActionContext cohEventActionContext = new CohEventActionContext(pdf(new byte[]{2, 5, 6, 0, 1}, pdfName), caseDetails);
         when(emailMessageBuilder.getAnswerMessage(caseDetails)).thenReturn("some message");
+        when(storeAnswersPdfService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails)))
+                .thenReturn(cohEventActionContext);
 
-        CohEventActionContext result = deadlineElapsedEventAction.handle(caseId, onlineHearingId, cohEventActionContext);
+        CohEventActionContext result = deadlineElapsedEventAction.handle(caseId, onlineHearingId, caseDetails);
 
         verify(corEmailService).sendFileToDwp(cohEventActionContext, "Appellant has provided information (" + someCaseReference + ")", "some message");
         assertThat(result, is(cohEventActionContext));

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/DecisionIssuedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/DecisionIssuedEventActionTest.java
@@ -7,21 +7,25 @@ import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someStorePdfResult
 
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions.DecisionIssuedEventAction;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreOnlineHearingTribunalsViewService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
 
 public class DecisionIssuedEventActionTest {
 
     private CorEmailService corEmailService;
     private EmailMessageBuilder emailMessageBuilder;
     private DecisionIssuedEventAction decisionIssuedEventAction;
+    private StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService;
 
     @Before
     public void setUp() {
-        StoreOnlineHearingTribunalsViewService storeOnlineHearingTribunalsViewService = mock(StoreOnlineHearingTribunalsViewService.class);
+        storeOnlineHearingTribunalsViewService = mock(StoreOnlineHearingTribunalsViewService.class);
         corEmailService = mock(CorEmailService.class);
         emailMessageBuilder = mock(EmailMessageBuilder.class);
 
@@ -41,7 +45,15 @@ public class DecisionIssuedEventActionTest {
         long caseId = 123L;
         String onlineHearingId = "onlineHearingId";
 
-        CohEventActionContext result = decisionIssuedEventAction.handle(caseId, onlineHearingId, cohEventActionContext);
+        SscsCaseDetails caseDetails = SscsCaseDetails.builder()
+                .data(SscsCaseData.builder()
+                        .caseReference("caseReference")
+                        .build())
+                .build();
+        when(storeOnlineHearingTribunalsViewService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails)))
+                .thenReturn(cohEventActionContext);
+
+        CohEventActionContext result = decisionIssuedEventAction.handle(caseId, onlineHearingId, caseDetails);
 
         String subject = "Preliminary view offered (" + cohEventActionContext.getDocument().getData().getCaseReference() + ")";
         verify(corEmailService).sendFileToDwp(cohEventActionContext, subject, message);

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/HearingRelistedActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/HearingRelistedActionTest.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreOnlineHearingService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.UploadedEvidence;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.CohService;
@@ -35,6 +36,7 @@ public class HearingRelistedActionTest {
     private CorEmailService corEmailService;
     private EmailMessageBuilder emailMessageBuilder;
     private CohService cohService;
+    private StoreOnlineHearingService storeOnlineHearingService;
 
     @Before
     public void setUp() {
@@ -48,7 +50,8 @@ public class HearingRelistedActionTest {
 
         emailMessageBuilder = mock(EmailMessageBuilder.class);
         cohService = mock(CohService.class);
-        underTest = new HearingRelistedAction(mock(StoreOnlineHearingService.class), corCcdService, idamService, corEmailService, emailMessageBuilder, cohService);
+        storeOnlineHearingService = mock(StoreOnlineHearingService.class);
+        underTest = new HearingRelistedAction(storeOnlineHearingService, corCcdService, idamService, corEmailService, emailMessageBuilder, cohService);
     }
 
     @Test
@@ -65,8 +68,10 @@ public class HearingRelistedActionTest {
         when(emailMessageBuilder.getRelistedMessage(sscsCaseDetails)).thenReturn("message body");
         String relistingReason = "relisting reason";
         when(cohService.getConversations(onlineHearingId)).thenReturn(DataFixtures.someCohConversations(relistingReason));
+        when(storeOnlineHearingService.storePdf(caseId, onlineHearingId, new PdfData(sscsCaseDetails)))
+                .thenReturn(cohEventActionContext);
 
-        CohEventActionContext result = underTest.handle(caseId, onlineHearingId, cohEventActionContext);
+        CohEventActionContext result = underTest.handle(caseId, onlineHearingId, sscsCaseDetails);
 
         ArgumentMatcher<SscsCaseData> hasOralHearing = data -> "oral".equals(data.getAppeal().getHearingType());
         ArgumentMatcher<SscsCaseData> hasRelistingReason = data -> relistingReason.equals(data.getRelistingReason());

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/QuestionRoundIssuedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/QuestionRoundIssuedEventActionTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreQuestionsPdfService;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
 
 public class QuestionRoundIssuedEventActionTest {
     private CorEmailService corEmailService;
@@ -20,10 +21,11 @@ public class QuestionRoundIssuedEventActionTest {
     private Long caseId;
     private String hearingId;
     private EmailMessageBuilder emailMessageBuilder;
+    private StoreQuestionsPdfService storeQuestionsPdfService;
 
     @Before
     public void setUp() {
-        StoreQuestionsPdfService storeQuestionsPdfService = mock(StoreQuestionsPdfService.class);
+        storeQuestionsPdfService = mock(StoreQuestionsPdfService.class);
         corEmailService = mock(CorEmailService.class);
         emailMessageBuilder = mock(EmailMessageBuilder.class);
         questionRoundIssuedEventAction = new QuestionRoundIssuedEventAction(
@@ -45,8 +47,10 @@ public class QuestionRoundIssuedEventActionTest {
         when(cohEventActionContext.getDocument()).thenReturn(sscsCaseDetails);
         String message = "message";
         when(emailMessageBuilder.getQuestionMessage(sscsCaseDetails)).thenReturn(message);
+        when(storeQuestionsPdfService.storePdf(caseId, hearingId, new PdfData(sscsCaseDetails)))
+                .thenReturn(cohEventActionContext);
 
-        CohEventActionContext result = questionRoundIssuedEventAction.handle(caseId, hearingId, cohEventActionContext);
+        CohEventActionContext result = questionRoundIssuedEventAction.handle(caseId, hearingId, sscsCaseDetails);
 
         verify(corEmailService).sendFileToDwp(cohEventActionContext, "Questions issued to the appellant (" + caseReference + ")", message);
         assertThat(result, is(cohEventActionContext));


### PR DESCRIPTION
When you submit multiple answers in a question round the answers pdf was
only showing the first answer. This is because the answer_submit event
is received for every answer and the store pdf service will not
recreate and store pdfs if it thinks they have already been created.

Have
- Made AnswerSubmittedEventAction check all questions in the round have
been submitted before creating the pdf. If the appellant does not submit
all their answers the round will eventually time out and a deadline
elapsed event will be received and generate the PDF.
- Refactored Actions so they no longer have handle and
createAndStorePdf methods. These can be done in one and means we only
need to check if a round has been answered once.

https://tools.hmcts.net/jira/browse/SSCS-5566

```
[ ] Yes
[X] No
```
