### PR TITLE
SSCS-5546 Send evidence for questions to DWP

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionTest.java
@@ -100,17 +100,25 @@ public class QuestionTest extends BaseIntegrationTest {
         String answerId = UUID.randomUUID().toString();
         String answer = "answer";
         long caseId = 123L;
+        cohStub.stubGetQuestionWithAnswer(
+                hearingId, questionId, "question header", "question body", answer, answerId, "answer_drafted", ZonedDateTime.now()
+        );
         cohStub.stubGetAnswer(hearingId, questionId, answer, answerId, "answer_drafted", ZonedDateTime.now());
+
         cohStub.stubUpdateAnswer(hearingId, questionId, answer, answerId, submitted);
         cohStub.stubGetOnlineHearing(caseId, hearingId);
-        ccdStub.stubFindCaseByCaseId(caseId, "1", "someEvidence", "01-01-2010", "http://evidenceUrl");
+        ccdStub.stubFindCaseByCaseId(caseId, "1", "someEvidence", "01-01-2010", "http://localhost:4603/documents/123");
         ccdStub.stubUpdateCaseWithEvent(caseId, "uploadCorDocument", "caseRef");
+        String evidenceFileContent = "Evidence pdf";
+        documentStoreStub.stubGetFile("/documents/123", evidenceFileContent);
 
         getRequest()
                 .when()
                 .post("/continuous-online-hearings/" + hearingId + "/questions/" + questionId)
                 .then()
                 .statusCode(HttpStatus.NO_CONTENT.value());
+
+        mailStub.hasEmailWithSubjectAndAttachment("Evidence uploaded (caseRef)", evidenceFileContent.getBytes());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
@@ -40,7 +40,8 @@ public class CcdStub extends BaseStub {
             "              \"documentFileName\": \"{evidenceFileName}\",\n" +
             "              \"documentDateAdded\": \"{evidenceCreatedDate}\",\n" +
             "              \"documentLink\": {\n" +
-            "                \"document_url\": \"{evidenceUrl}\"\n" +
+            "                \"document_url\": \"{evidenceUrl}\",\n" +
+            "                \"document_binary_url\": \"{evidenceUrl}\"\n" +
             "              }\n" +
             "            },\n" +
             "            \"questionId\": \"{evidenceQuestionId}\"\n" +

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CohStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CohStub.java
@@ -33,6 +33,22 @@ public class CohStub extends BaseStub {
             "  \"question_round\": \"1\"\n" +
             "}";
 
+    private static final String getQuestionWithAnswerJson = "{\n" +
+            "  \"current_question_state\": {\n" +
+            "    \"state_datetime\": \"string\",\n" +
+            "    \"state_name\": \"string\"\n" +
+            "  },\n" +
+            "  \"deadline_expiry_date\": \"string\",\n" +
+            "  \"owner_reference\": \"string\",\n" +
+            "  \"question_body_text\": \"{question_body}\",\n" +
+            "  \"question_header_text\": \"{question_header}\",\n" +
+            "  \"question_id\": \"string\",\n" +
+            "  \"question_ordinal\": \"1\",\n" +
+            "  \"question_round\": \"1\"," +
+            "  \"answers\": {answers}\n" +
+            "}";
+
+
     private static final String getAnswersJson = "[\n" +
             "  {\n" +
             "    \"answer_id\": \"{answer_id}\",\n" +
@@ -145,6 +161,13 @@ public class CohStub extends BaseStub {
         );
     }
 
+    public void stubGetQuestionWithAnswer(String hearingId, String questionId, String questionHeader, String questionBody, String answer, String answerId, String answerState, ZonedDateTime answerDate) {
+        wireMock.stubFor(get(urlEqualTo("/continuous-online-hearings/" + hearingId + "/questions/" + questionId))
+                .withHeader("ServiceAuthorization", new RegexPattern(".*"))
+                .willReturn(okJson(buildGetQuestionWithAnswerBody(questionHeader, questionBody, answer, answerId, answerState, answerDate)))
+        );
+    }
+
     public void stubGetAnswer(String hearingId, String questionId, String answer) {
         stubGetAnswer(hearingId, questionId, answer, UUID.randomUUID().toString(), "draft", ZonedDateTime.now());
     }
@@ -159,6 +182,13 @@ public class CohStub extends BaseStub {
     private String buildGetQuestionBody(String questionHeader, String questionBody) {
         return getQuestionJson.replace("{question_header}", questionHeader)
                 .replace("{question_body}", questionBody);
+    }
+
+    private String buildGetQuestionWithAnswerBody(String questionHeader, String questionBody, String answer, String answerId, String answerState, ZonedDateTime answerDate) {
+        String answerJson = buildGetAnswerBody(answer, answerId, answerState, answerDate);
+        return getQuestionWithAnswerJson.replace("{question_header}", questionHeader)
+                .replace("{question_body}", questionBody)
+                .replace("{answers}", answerJson);
     }
 
     private String buildGetAnswerBody(String answer, String answerId, String answerState, ZonedDateTime answerDate) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CohStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CohStub.java
@@ -42,7 +42,7 @@ public class CohStub extends BaseStub {
             "  \"owner_reference\": \"string\",\n" +
             "  \"question_body_text\": \"{question_body}\",\n" +
             "  \"question_header_text\": \"{question_header}\",\n" +
-            "  \"question_id\": \"string\",\n" +
+            "  \"question_id\": \"{question_id}\",\n" +
             "  \"question_ordinal\": \"1\",\n" +
             "  \"question_round\": \"1\"," +
             "  \"answers\": {answers}\n" +
@@ -164,7 +164,7 @@ public class CohStub extends BaseStub {
     public void stubGetQuestionWithAnswer(String hearingId, String questionId, String questionHeader, String questionBody, String answer, String answerId, String answerState, ZonedDateTime answerDate) {
         wireMock.stubFor(get(urlEqualTo("/continuous-online-hearings/" + hearingId + "/questions/" + questionId))
                 .withHeader("ServiceAuthorization", new RegexPattern(".*"))
-                .willReturn(okJson(buildGetQuestionWithAnswerBody(questionHeader, questionBody, answer, answerId, answerState, answerDate)))
+                .willReturn(okJson(buildGetQuestionWithAnswerBody(questionId, questionHeader, questionBody, answer, answerId, answerState, answerDate)))
         );
     }
 
@@ -184,9 +184,11 @@ public class CohStub extends BaseStub {
                 .replace("{question_body}", questionBody);
     }
 
-    private String buildGetQuestionWithAnswerBody(String questionHeader, String questionBody, String answer, String answerId, String answerState, ZonedDateTime answerDate) {
+    private String buildGetQuestionWithAnswerBody(String questionId, String questionHeader, String questionBody, String answer, String answerId, String answerState, ZonedDateTime answerDate) {
         String answerJson = buildGetAnswerBody(answer, answerId, answerState, answerDate);
-        return getQuestionWithAnswerJson.replace("{question_header}", questionHeader)
+        return getQuestionWithAnswerJson
+                .replace("{question_id}", questionId)
+                .replace("{question_header}", questionHeader)
                 .replace("{question_body}", questionBody)
                 .replace("{answers}", answerJson);
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/Question.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/Question.java
@@ -16,6 +16,7 @@ public class Question {
     private final int questionOrdinal;
     private final String questionHeaderText;
     private final String questionBodyText;
+    private final String answerId;
     private final String answer;
     private final AnswerState answerState;
     private final String answerDate;
@@ -26,6 +27,7 @@ public class Question {
                     int questionOrdinal,
                     String questionHeaderText,
                     String questionBodyText,
+                    String answerId,
                     String answer,
                     AnswerState answerState,
                     String answerDate,
@@ -35,6 +37,7 @@ public class Question {
         this.questionOrdinal = questionOrdinal;
         this.questionHeaderText = questionHeaderText;
         this.questionBodyText = questionBodyText;
+        this.answerId = answerId;
         this.answer = answer;
         this.answerState = answerState;
         this.answerDate = answerDate;
@@ -69,6 +72,10 @@ public class Question {
     @JsonProperty(value = "question_body_text")
     public String getQuestionBodyText() {
         return questionBodyText;
+    }
+
+    public String getAnswerId() {
+        return answerId;
     }
 
     @ApiModelProperty(example = "An answer to a question")
@@ -110,6 +117,7 @@ public class Question {
                 Objects.equals(questionHeaderText, question.questionHeaderText) &&
                 Objects.equals(questionBodyText, question.questionBodyText) &&
                 Objects.equals(evidence, question.evidence) &&
+                Objects.equals(answerId, question.answerId) &&
                 Objects.equals(answer, question.answer) &&
                 answerState == question.answerState &&
                 Objects.equals(answerDate, question.answerDate);
@@ -117,7 +125,7 @@ public class Question {
 
     @Override
     public int hashCode() {
-        return Objects.hash(onlineHearingId, questionId, questionOrdinal, questionHeaderText, questionBodyText, evidence, answer, answerState, answerDate);
+        return Objects.hash(onlineHearingId, questionId, questionOrdinal, questionHeaderText, questionBodyText, evidence, answerId, answer, answerState, answerDate);
     }
 
     @Override
@@ -129,6 +137,7 @@ public class Question {
                 ", questionHeaderText='" + questionHeaderText + '\'' +
                 ", questionBodyText='" + questionBodyText + '\'' +
                 ", evidence=" + evidence +
+                ", answerId='" + answerId + '\'' +
                 ", answer='" + answer + '\'' +
                 ", answerState=" + answerState +
                 ", answerDate='" + answerDate + '\'' +

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
@@ -75,7 +75,7 @@ public class QuestionService {
         if (question != null && unanswered != question.getAnswerState()) {
             CohUpdateAnswer updatedAnswer = new CohUpdateAnswer(AnswerState.submitted.getCohAnswerState(), question.getAnswer());
             cohService.updateAnswer(onlineHearingId, questionId, question.getAnswerId(), updatedAnswer);
-            evidenceUploadService.submitQuestionEvidence(question.getQuestionHeaderText(), onlineHearingId, questionId);
+            evidenceUploadService.submitQuestionEvidence(onlineHearingId, question);
 
             return true;
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilder.java
@@ -1,10 +1,13 @@
 package uk.gov.hmcts.reform.sscscorbackend.service.email;
 
+import java.time.LocalDate;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.PdfDateUtil;
 
 @Service
 public class EmailMessageBuilder {
@@ -78,16 +81,19 @@ public class EmailMessageBuilder {
     }
 
     public String getEvidenceSubmittedMessage(SscsCaseDetails sscsCaseDetails) {
-        return buildMessageWithHeading(sscsCaseDetails, "The appellant has submitted evidence to the tribunal. The evidence is attached.",
-                "Additional evidence submitted");
+        String submittedDate = PdfDateUtil.reformatDate(LocalDate.now());
+        return buildMessageWithHeading(sscsCaseDetails, "Additional evidence was received by the tribunal for the above appeal on " +
+                        submittedDate + ".",
+                "Additional evidence submitted by appellant");
     }
 
-    public String getQuestionEvidenceSubmittedMessage(SscsCaseDetails sscsCaseDetails, String questionSubject) {
+    public String getQuestionEvidenceSubmittedMessage(SscsCaseDetails sscsCaseDetails, Question question) {
         return buildMessageWithHeading(sscsCaseDetails,
-                "The appellant has submitted evidence to the tribunal. The evidence relates to the question\n\n" +
-                        questionSubject +
-                        "\n\nThe evidence is attached.",
-                "Additional evidence submitted");
+                "Additional evidence was received by the tribunal for the above appeal on " +
+                        PdfDateUtil.reformatDateTimeToDate(question.getAnswerDate()) +
+                        ". It was submitted in relation to the question " +
+                        question.getQuestionHeaderText(),
+                "Additional evidence submitted in relation to question");
     }
 
     private String buildMessageWithHeading(SscsCaseDetails caseDetails, String message, String heading) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilder.java
@@ -82,6 +82,14 @@ public class EmailMessageBuilder {
                 "Additional evidence submitted");
     }
 
+    public String getQuestionEvidenceSubmittedMessage(SscsCaseDetails sscsCaseDetails, String questionSubject) {
+        return buildMessageWithHeading(sscsCaseDetails,
+                "The appellant has submitted evidence to the tribunal. The evidence relates to the question\n\n" +
+                        questionSubject +
+                        "\n\nThe evidence is attached.",
+                "Additional evidence submitted");
+    }
+
     private String buildMessageWithHeading(SscsCaseDetails caseDetails, String message, String heading) {
         String templateWithHeading = TEMPLATE_WITH_HEADING.replace("{heading}", heading);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailService.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.CorDocument;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentDetails;
+import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.UploadedEvidence;
@@ -37,8 +38,8 @@ public class EvidenceUploadEmailService {
         );
     }
 
-    public void sendToDwp(String questionSubject, List<CorDocument> newEvidence, SscsCaseDetails sscsCaseDetails) {
-        String message = emailMessageBuilder.getQuestionEvidenceSubmittedMessage(sscsCaseDetails, questionSubject);
+    public void sendToDwp(Question question, List<CorDocument> newEvidence, SscsCaseDetails sscsCaseDetails) {
+        String message = emailMessageBuilder.getQuestionEvidenceSubmittedMessage(sscsCaseDetails, question);
         String subject = "Evidence uploaded (" + sscsCaseDetails.getData().getCaseReference() + ")";
 
         sendFileToDwp(

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
@@ -132,7 +132,7 @@ public class EvidenceUploadService {
                 .orElse(false);
     }
 
-    public boolean submitQuestionEvidence(String onlineHearingId, String questionId) {
+    public boolean submitQuestionEvidence(String questionSubject, String onlineHearingId, String questionId) {
         return onlineHearingService.getCcdCase(onlineHearingId)
                 .map(caseDetails -> {
                     Long ccdCaseId = caseDetails.getId();
@@ -154,6 +154,9 @@ public class EvidenceUploadService {
                         sscsCaseData.setCorDocument(newCorDocumentList);
                         sscsCaseData.setDraftCorDocument(draftCorDocumentsForQuestionId.get(false));
                         ccdService.updateCase(sscsCaseData, ccdCaseId, UPLOAD_COR_DOCUMENT, "SSCS - cor evidence uploaded", UPDATED_SSCS, idamService.getIdamTokens());
+
+                        List<CorDocument> corDocuments = draftCorDocumentsForQuestionId.get(true);
+                        evidenceUploadEmailService.sendToDwp(questionSubject, corDocuments, caseDetails);
                     }
                     return true;
                 })

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/util/PdfDateUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/util/PdfDateUtil.java
@@ -13,6 +13,13 @@ public final class PdfDateUtil {
 
     }
 
+    public static String reformatDateTimeToDate(String dateString) {
+        if (isNotBlank(dateString)) {
+            return reformatDate(dateString.substring(0, 10));
+        }
+        return dateString;
+    }
+
     public static String reformatDate(String dateString) {
         if (isNotBlank(dateString)) {
             return reformatDate(LocalDate.parse(dateString));

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -38,7 +38,7 @@ public class DataFixtures {
     }
 
     public static Question someQuestion() {
-        return new Question("someHearingId", "someQuestionId", 1, "someQuestionHeader", "someBody", "someAnswer", draft, "2018-08-08T09:12:12Z", emptyList());
+        return new Question("someHearingId", "someQuestionId", 1, "someQuestionHeader", "someBody", "answerId", "someAnswer", draft, "2018-08-08T09:12:12Z", emptyList());
     }
 
     public static CohQuestion someCohQuestion() {

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionServiceTest.java
@@ -12,7 +12,10 @@ import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.*;
 import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.*;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscscorbackend.domain.*;
@@ -331,7 +334,7 @@ public class QuestionServiceTest {
 
         assertThat(hasBeenSubmitted, is(true));
         verify(cohService).updateAnswer(onlineHearingId, questionId, answerId, new CohUpdateAnswer(submitted.getCohAnswerState(), answer));
-        verify(evidenceUploadService).submitQuestionEvidence(questionHeader, onlineHearingId, questionId);
+        verify(evidenceUploadService).submitQuestionEvidence(eq(onlineHearingId), argThat(argument -> questionId.equals(argument.getQuestionId())));
     }
 
     @Test
@@ -344,7 +347,7 @@ public class QuestionServiceTest {
 
         assertThat(hasBeenSubmitted, is(false));
         verify(cohService, never()).updateAnswer(any(), any(), any(), any());
-        verify(evidenceUploadService, never()).submitQuestionEvidence(any(), any(), any());
+        verify(evidenceUploadService, never()).submitQuestionEvidence(any(), any());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilderTest.java
@@ -3,9 +3,13 @@ package uk.gov.hmcts.reform.sscscorbackend.service.email;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
+import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
+import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.PdfDateUtil;
 
 public class EmailMessageBuilderTest {
 
@@ -164,15 +168,17 @@ public class EmailMessageBuilderTest {
     @Test
     public void buildEvidenceSubmitted() {
         String message = new EmailMessageBuilder().getEvidenceSubmittedMessage(caseDetails);
+        String submittedDate = PdfDateUtil.reformatDate(LocalDate.now());
 
         assertThat(message, is(
-                "Additional evidence submitted\n" +
+                "Additional evidence submitted by appellant\n" +
                         "\n" +
                         "Appeal reference number: caseReference\n" +
                         "Appellant name: Jean Valjean\n" +
                         "Appellant NINO: JV123456\n" +
                         "\n" +
-                        "The appellant has submitted evidence to the tribunal. The evidence is attached.\n" +
+                        "Additional evidence was received by the tribunal for the above appeal on " +
+                        submittedDate + ".\n" +
                         "\n" +
                         "PIP Benefit Appeals\n" +
                         "HMCTS\n"));
@@ -180,21 +186,21 @@ public class EmailMessageBuilderTest {
 
     @Test
     public void buildQuestionEvidenceSubmitted() {
-        String message = new EmailMessageBuilder().getQuestionEvidenceSubmittedMessage(caseDetails, "This is the question subject");
+        Question question = DataFixtures.someQuestion();
+        String questionHeaderText = question.getQuestionHeaderText();
+        String message = new EmailMessageBuilder().getQuestionEvidenceSubmittedMessage(caseDetails, question);
 
         assertThat(message, is(
-                "Additional evidence submitted\n" +
+                "Additional evidence submitted in relation to question\n" +
                         "\n" +
                         "Appeal reference number: caseReference\n" +
                         "Appellant name: Jean Valjean\n" +
                         "Appellant NINO: JV123456\n" +
                         "\n" +
-                        "The appellant has submitted evidence to the tribunal. The evidence relates to the question\n" +
-                        "\n" +
-                        "This is the question subject" +
-                        "\n" +
-                        "\nThe evidence is attached.\n" +
-                        "\n" +
+                        "Additional evidence was received by the tribunal for the above appeal on 08 August 2018. " +
+                        "It was submitted in relation to the question " +
+                        questionHeaderText +
+                        "\n\n" +
                         "PIP Benefit Appeals\n" +
                         "HMCTS\n"));
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilderTest.java
@@ -177,4 +177,25 @@ public class EmailMessageBuilderTest {
                         "PIP Benefit Appeals\n" +
                         "HMCTS\n"));
     }
+
+    @Test
+    public void buildQuestionEvidenceSubmitted() {
+        String message = new EmailMessageBuilder().getQuestionEvidenceSubmittedMessage(caseDetails, "This is the question subject");
+
+        assertThat(message, is(
+                "Additional evidence submitted\n" +
+                        "\n" +
+                        "Appeal reference number: caseReference\n" +
+                        "Appellant name: Jean Valjean\n" +
+                        "Appellant NINO: JV123456\n" +
+                        "\n" +
+                        "The appellant has submitted evidence to the tribunal. The evidence relates to the question\n" +
+                        "\n" +
+                        "This is the question subject" +
+                        "\n" +
+                        "\nThe evidence is attached.\n" +
+                        "\n" +
+                        "PIP Benefit Appeals\n" +
+                        "HMCTS\n"));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailServiceTest.java
@@ -67,4 +67,41 @@ public class EvidenceUploadEmailServiceTest {
                 eq(message)
         );
     }
+
+    @Test
+    public void sendsQuestionEvidenceToDwp() {
+        String message = "some message";
+        String docUrl = "docUrl";
+        String fileName = "fileName";
+
+        CorDocument corDocument = CorDocument.builder()
+                .value(CorDocumentDetails.builder()
+                        .document(SscsDocumentDetails.builder()
+                                .documentFileName(fileName)
+                                .documentLink(DocumentLink.builder()
+                                        .documentBinaryUrl(docUrl)
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        String questionSubject = "some question subject";
+
+        when(emailMessageBuilder.getQuestionEvidenceSubmittedMessage(sscsCaseDetails, questionSubject)).thenReturn(message);
+        UploadedEvidence expectedFile = mock(UploadedEvidence.class);
+        when(fileDownloader.downloadFile(docUrl)).thenReturn(expectedFile);
+
+        new EvidenceUploadEmailService(corEmailService, emailMessageBuilder, fileDownloader).sendToDwp(
+                questionSubject,
+                singletonList(corDocument),
+                sscsCaseDetails
+        );
+
+        verify(fileDownloader).downloadFile(docUrl);
+        verify(corEmailService, times(1)).sendFileToDwp(
+                eq(expectedFile),
+                eq("Evidence uploaded (" + caseReference + ")"),
+                eq(message)
+        );
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailServiceTest.java
@@ -7,6 +7,8 @@ import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.UploadedEviden
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
+import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.UploadedEvidence;
@@ -85,14 +87,15 @@ public class EvidenceUploadEmailServiceTest {
                         .build())
                 .build();
 
-        String questionSubject = "some question subject";
 
-        when(emailMessageBuilder.getQuestionEvidenceSubmittedMessage(sscsCaseDetails, questionSubject)).thenReturn(message);
+        Question question = DataFixtures.someQuestion();
+
+        when(emailMessageBuilder.getQuestionEvidenceSubmittedMessage(sscsCaseDetails, question)).thenReturn(message);
         UploadedEvidence expectedFile = mock(UploadedEvidence.class);
         when(fileDownloader.downloadFile(docUrl)).thenReturn(expectedFile);
 
         new EvidenceUploadEmailService(corEmailService, emailMessageBuilder, fileDownloader).sendToDwp(
-                questionSubject,
+                question,
                 singletonList(corDocument),
                 sscsCaseDetails
         );

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadServiceTest.java
@@ -23,8 +23,10 @@ import uk.gov.hmcts.reform.document.domain.UploadResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+import uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState;
 import uk.gov.hmcts.reform.sscscorbackend.domain.Evidence;
 import uk.gov.hmcts.reform.sscscorbackend.domain.EvidenceDescription;
+import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
 import uk.gov.hmcts.reform.sscscorbackend.service.OnlineHearingService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreEvidenceDescriptionService;
@@ -194,10 +196,11 @@ public class EvidenceUploadServiceTest {
         String questionHeader = "question header";
         List<CorDocument> draftCorDocument = sscsCaseDetails.getData().getDraftCorDocument();
 
-        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(questionHeader, someOnlineHearingId, someQuestionId);
+        Question question = createQuestion(questionHeader);
+        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, question);
 
         assertThat(submittedEvidence, is(true));
-        verify(evidenceUploadEmailService).sendToDwp(questionHeader, draftCorDocument, sscsCaseDetails);
+        verify(evidenceUploadEmailService).sendToDwp(question, draftCorDocument, sscsCaseDetails);
         verify(ccdService).updateCase(
                 and(hasCorDocument(0, someQuestionId, documentUrl, fileName), doesNotHaveDraftCorDocuments()),
                 eq(someCcdCaseId),
@@ -206,6 +209,10 @@ public class EvidenceUploadServiceTest {
                 eq("Updated SSCS"),
                 eq(idamTokens)
         );
+    }
+
+    private Question createQuestion(String questionHeader) {
+        return new Question(someOnlineHearingId, someQuestionId, 1, questionHeader, "questionBody", "answerId", "someAnswer", AnswerState.draft, "2018-10-10", emptyList());
     }
 
     @Test
@@ -220,10 +227,11 @@ public class EvidenceUploadServiceTest {
         String questionHeader = "question header";
         List<CorDocument> draftCorDocument = sscsCaseDetails.getData().getDraftCorDocument();
 
-        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(questionHeader, someOnlineHearingId, someQuestionId);
+        Question question = createQuestion(questionHeader);
+        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, question);
 
         assertThat(submittedEvidence, is(true));
-        verify(evidenceUploadEmailService).sendToDwp(questionHeader, draftCorDocument, sscsCaseDetails);
+        verify(evidenceUploadEmailService).sendToDwp(question, draftCorDocument, sscsCaseDetails);
         verify(ccdService).updateCase(
                 and(hasCorDocument(originalNumberOfSscsDocuments, someQuestionId, documentUrl, fileName), doesNotHaveDraftCorDocuments()),
                 eq(someCcdCaseId),
@@ -251,11 +259,12 @@ public class EvidenceUploadServiceTest {
 
         when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
         String questionHeader = "question header";
+        Question question = createQuestion(questionHeader);
 
-        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(questionHeader, someOnlineHearingId, someQuestionId);
+        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, question);
 
         assertThat(submittedEvidence, is(true));
-        verify(evidenceUploadEmailService).sendToDwp(questionHeader, asList(expectedCorDocument), sscsCaseDetails);
+        verify(evidenceUploadEmailService).sendToDwp(question, asList(expectedCorDocument), sscsCaseDetails);
         verify(ccdService).updateCase(
                 and(hasCorDocument(0, someQuestionId, expectedUrl, expectedFileName), hasDraftCorDocument(0, draftQuestionId, draftDocumentUrl, draftFileName)),
                 eq(someCcdCaseId),
@@ -274,8 +283,9 @@ public class EvidenceUploadServiceTest {
 
         when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
         String questionHeader = "question header";
+        Question question = createQuestion(questionHeader);
 
-        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(questionHeader, someOnlineHearingId, someQuestionId);
+        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, question);
 
         assertThat(submittedEvidence, is(true));
         verifyZeroInteractions(evidenceUploadEmailService);

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadServiceTest.java
@@ -191,9 +191,13 @@ public class EvidenceUploadServiceTest {
                 new EvidenceDescriptionPdfData(sscsCaseDetails, someDescription, singletonList(fileName))
         )).thenReturn(new CohEventActionContext(mock(UploadedEvidence.class), sscsCaseDetails));
 
-        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, someQuestionId);
+        String questionHeader = "question header";
+        List<CorDocument> draftCorDocument = sscsCaseDetails.getData().getDraftCorDocument();
+
+        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(questionHeader, someOnlineHearingId, someQuestionId);
 
         assertThat(submittedEvidence, is(true));
+        verify(evidenceUploadEmailService).sendToDwp(questionHeader, draftCorDocument, sscsCaseDetails);
         verify(ccdService).updateCase(
                 and(hasCorDocument(0, someQuestionId, documentUrl, fileName), doesNotHaveDraftCorDocuments()),
                 eq(someCcdCaseId),
@@ -213,9 +217,13 @@ public class EvidenceUploadServiceTest {
         final int originalNumberOfSscsDocuments = sscsCaseDetails.getData().getCorDocument().size();
         when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
-        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, someQuestionId);
+        String questionHeader = "question header";
+        List<CorDocument> draftCorDocument = sscsCaseDetails.getData().getDraftCorDocument();
+
+        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(questionHeader, someOnlineHearingId, someQuestionId);
 
         assertThat(submittedEvidence, is(true));
+        verify(evidenceUploadEmailService).sendToDwp(questionHeader, draftCorDocument, sscsCaseDetails);
         verify(ccdService).updateCase(
                 and(hasCorDocument(originalNumberOfSscsDocuments, someQuestionId, documentUrl, fileName), doesNotHaveDraftCorDocuments()),
                 eq(someCcdCaseId),
@@ -234,17 +242,20 @@ public class EvidenceUploadServiceTest {
         String expectedFileName = "file2";
         String expectedUrl = "http://url2";
         String draftQuestionId = "1";
-        List<CorDocument> list = asList(
+        CorDocument expectedCorDocument = createCorDocument(expectedFileName, expectedUrl, someQuestionId);
+        List<CorDocument> draftCorDocuments = asList(
                 createCorDocument(draftFileName, draftDocumentUrl, draftQuestionId),
-                createCorDocument(expectedFileName, expectedUrl, someQuestionId)
+                expectedCorDocument
         );
-        sscsCaseDetails.getData().setDraftCorDocument(list);
+        sscsCaseDetails.getData().setDraftCorDocument(draftCorDocuments);
 
         when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        String questionHeader = "question header";
 
-        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, someQuestionId);
+        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(questionHeader, someOnlineHearingId, someQuestionId);
 
         assertThat(submittedEvidence, is(true));
+        verify(evidenceUploadEmailService).sendToDwp(questionHeader, asList(expectedCorDocument), sscsCaseDetails);
         verify(ccdService).updateCase(
                 and(hasCorDocument(0, someQuestionId, expectedUrl, expectedFileName), hasDraftCorDocument(0, draftQuestionId, draftDocumentUrl, draftFileName)),
                 eq(someCcdCaseId),
@@ -262,10 +273,12 @@ public class EvidenceUploadServiceTest {
         sscsCaseDetails.getData().setCorDocument(null);
 
         when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        String questionHeader = "question header";
 
-        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, someQuestionId);
+        boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(questionHeader, someOnlineHearingId, someQuestionId);
 
         assertThat(submittedEvidence, is(true));
+        verifyZeroInteractions(evidenceUploadEmailService);
         verifyZeroInteractions(ccdService);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/util/PdfDateUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/util/PdfDateUtilTest.java
@@ -4,6 +4,7 @@ import static java.time.LocalDate.parse;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.PdfDateUtil.reformatDate;
+import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.PdfDateUtil.reformatDateTimeToDate;
 
 import org.junit.Test;
 
@@ -27,5 +28,19 @@ public class PdfDateUtilTest {
         String reformatDate = reformatDate(parse("2001-06-24"));
 
         assertThat(reformatDate, is("24 June 2001"));
+    }
+
+    @Test
+    public void formatsDateTime() {
+        String reformatDate = reformatDateTimeToDate("2007-12-03T10:15:30Z");
+
+        assertThat(reformatDate, is("03 December 2007"));
+    }
+
+    @Test
+    public void formatsDateTimeWithOffset() {
+        String reformatDate = reformatDateTimeToDate("2019-05-10T15:24:21+01:00");
+
+        assertThat(reformatDate, is("10 May 2019"));
     }
 }


### PR DESCRIPTION
When an appellant submits an answer with evidence the evidence needs to
be sent to dwp. Send an email for each piece of evidence to DWP.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-5546

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
