### PR TITLE
Separate caseworker and from email address

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -96,6 +96,7 @@ module "sscs-core-backend" {
     EMAIL_SERVER_PORT      = "${local.email_port}"
     DWP_EMAIL              = "${var.dwp_email}"
     EMAIL_FROM             = "${var.email_from_address}"
+    CASEWORKER_EMAIL       = "${var.caseworker_email_address}"
 
     PDF_SERVICE_ACCESS_KEY = "${data.azurerm_key_vault_secret.docmosis-api-key.value}"
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -53,6 +53,10 @@ variable "dwp_email" {
   default = "dwp_email@example.com"
 }
 
+variable "caseworker_email_address" {
+  default = "caseworker@example.net"
+}
+
 variable "email_from_address" {
   default = "sscs@hmcts.net"
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/RecordTribunalViewResponseTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/RecordTribunalViewResponseTest.java
@@ -32,7 +32,7 @@ public class RecordTribunalViewResponseTest extends BaseIntegrationTest {
                 .then()
                 .statusCode(HttpStatus.NO_CONTENT.value());
 
-        mailStub.hasEmailWithSubject("sscs@hmcts.net", "Tribunal view accepted (caseReference)");
+        mailStub.hasEmailWithSubject("caseworker@example.net", "Tribunal view accepted (caseReference)");
         mailStub.hasEmailWithSubject("dwp@example.com", "Tribunal view accepted (caseReference)");
     }
 
@@ -51,7 +51,7 @@ public class RecordTribunalViewResponseTest extends BaseIntegrationTest {
                 .then()
                 .statusCode(HttpStatus.NO_CONTENT.value());
 
-        mailStub.hasEmailWithSubject("sscs@hmcts.net", "Tribunal view rejected (caseReference)");
+        mailStub.hasEmailWithSubject("caseworker@example.net", "Tribunal view rejected (caseReference)");
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/email/CorEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/email/CorEmailService.java
@@ -18,15 +18,18 @@ public class CorEmailService {
     private final EmailService emailService;
     private final String fromEmailAddress;
     private final String dwpEmailAddress;
+    private final String caseworkerEmailAddress;
 
     public CorEmailService(
             @Autowired EmailService emailService,
             @Value("${appeal.email.from}") String fromEmailAddress,
-            @Value("${appeal.email.dwpEmailAddress}") String dwpEmailAddress
+            @Value("${appeal.email.dwpEmailAddress}") String dwpEmailAddress,
+            @Value("${appeal.email.caseworkerAddress}") String caseworkerEmailAddress
     ) {
         this.emailService = emailService;
         this.fromEmailAddress = fromEmailAddress;
         this.dwpEmailAddress = dwpEmailAddress;
+        this.caseworkerEmailAddress = caseworkerEmailAddress;
     }
 
     @Deprecated // use method below that takes a UploadedEvidence object
@@ -64,7 +67,7 @@ public class CorEmailService {
         log.info("Sending email with subject [" + subject + "] to caseworker");
         emailService.sendEmail(Email.builder()
                 .from(fromEmailAddress)
-                .to(fromEmailAddress)
+                .to(caseworkerEmailAddress)
                 .subject(subject)
                 .message(message)
                 .build());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -102,6 +102,7 @@ appeal:
     subject: ${EMAIL_SUBJECT:Not Used}
     message: ${EMAIL_MESSAGE:Not Used}
     dwpEmailAddress: ${DWP_EMAIL:dwp@example.com}
+    caseworkerAddress: ${CASEWORKER_EMAIL:caseworker@example.net}
 
 enable_debug_error_message: ${ENABLE_DEBUG_ERROR_MESSAGE:true}
 enable_select_by_case_id: ${ENABLE_SELECT_BY_CASE_ID:false}

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/email/CorEmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/email/CorEmailServiceTest.java
@@ -18,7 +18,8 @@ public class CorEmailServiceTest {
 
     private EmailService emailService;
     private String fromEmailAddress;
-    private String toEmailAddress;
+    private String dwpEmailAddress;
+    private String caseworkerEmailAddress;
     private String caseReference;
     private String pdfFileName;
 
@@ -26,14 +27,15 @@ public class CorEmailServiceTest {
     public void setUp() {
         emailService = mock(EmailService.class);
         fromEmailAddress = "from@example.com";
-        toEmailAddress = "to@example.com";
+        dwpEmailAddress = "to@example.com";
+        caseworkerEmailAddress = "caseworker@example.com";
         caseReference = "caseReference";
         pdfFileName = "pdfName.pdf";
     }
 
     @Test
     public void canSendEmailWithSubjectAndMessage() {
-        CorEmailService corEmailService = new CorEmailService(emailService, fromEmailAddress, toEmailAddress);
+        CorEmailService corEmailService = new CorEmailService(emailService, fromEmailAddress, dwpEmailAddress, caseworkerEmailAddress);
         byte[] pdfContent = {2, 4, 6, 0, 1};
         SscsCaseDetails sscsCaseDetails = SscsCaseDetails.builder()
                 .data(SscsCaseData.builder().caseReference(caseReference).build())
@@ -44,7 +46,7 @@ public class CorEmailServiceTest {
 
         verify(emailService).sendEmail(Email.builder()
                 .from(fromEmailAddress)
-                .to(toEmailAddress)
+                .to(dwpEmailAddress)
                 .subject(subject)
                 .message(message)
                 .attachments(singletonList(EmailAttachment.pdf(pdfContent, pdfFileName)))
@@ -53,14 +55,29 @@ public class CorEmailServiceTest {
 
     @Test
     public void canSendEmail() {
-        CorEmailService corEmailService = new CorEmailService(emailService, fromEmailAddress, toEmailAddress);
+        CorEmailService corEmailService = new CorEmailService(emailService, fromEmailAddress, dwpEmailAddress, caseworkerEmailAddress);
         String message = "Some message";
         String subject = "subject";
         corEmailService.sendEmailToDwp(subject, message);
 
         verify(emailService).sendEmail(Email.builder()
                 .from(fromEmailAddress)
-                .to(toEmailAddress)
+                .to(dwpEmailAddress)
+                .subject(subject)
+                .message(message)
+                .build());
+    }
+
+    @Test
+    public void canSendEmailToCaseworker() {
+        CorEmailService corEmailService = new CorEmailService(emailService, fromEmailAddress, dwpEmailAddress, caseworkerEmailAddress);
+        String message = "Some message";
+        String subject = "subject";
+        corEmailService.sendEmailToCaseworker(subject, message);
+
+        verify(emailService).sendEmail(Email.builder()
+                .from(fromEmailAddress)
+                .to(caseworkerEmailAddress)
                 .subject(subject)
                 .message(message)
                 .build());


### PR DESCRIPTION
Previously we had a single property value for the from address of emails
sent to DWP and the to address for emails sent to caseworkers as they
were going to be the same. Now they may want them to be different so
created separate properties for them.

```
[ ] Yes
[X] No
```
