### PR TITLE
SSCS-5546 Send DWP evidence email once round submitted

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -76,4 +76,8 @@
     <notes>We don't use the CGI Servlet</notes>
     <cve>CVE-2019-0232</cve>
   </suppress>
+  <suppress>
+    <notes>Only an issue if using mysql-connector-java is on the classpath</notes>
+    <cve>CVE-2019-12086</cve>
+  </suppress>
 </suppressions>

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscscorbackend/BaseFunctionTest.java
@@ -36,7 +36,8 @@ import uk.gov.hmcts.reform.sscscorbackend.thirdparty.ccd.CorCcdService;
         "core_case_data.api.url=http://ccd-data-store-api-aat.service.core-compute-aat.internal"
 })
 public abstract class BaseFunctionTest {
-    private final String baseUrl = System.getenv("TEST_URL");
+    private final String baseUrl = System.getenv("TEST_URL") != null ? System.getenv("TEST_URL") : "http://localhost:8090";
+
     private String cohBaseUrl = "http://coh-cor-aat.service.core-compute-aat.internal";
     private CloseableHttpClient client;
     private HttpClient cohClient;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/AppellantStatementTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/AppellantStatementTest.java
@@ -10,7 +10,7 @@ public class AppellantStatementTest extends BaseIntegrationTest {
     private final Long caseId = 123L;
     private final String hearingId = "hearingId";
     private String caseReference = "caseReference";
-    
+
     @Test
     public void recordRejectedResponse() throws JsonProcessingException {
         cohStub.stubGetOnlineHearing(caseId, hearingId);

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionTest.java
@@ -117,8 +117,6 @@ public class QuestionTest extends BaseIntegrationTest {
                 .post("/continuous-online-hearings/" + hearingId + "/questions/" + questionId)
                 .then()
                 .statusCode(HttpStatus.NO_CONTENT.value());
-
-        mailStub.hasEmailWithSubjectAndAttachment("Evidence uploaded (caseRef)", evidenceFileContent.getBytes());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CcdStub.java
@@ -11,7 +11,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
-import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 
 public class CcdStub extends BaseStub {
 
@@ -89,6 +89,16 @@ public class CcdStub extends BaseStub {
         );
     }
 
+    public void stubFindCaseByCaseId(Long caseId, SscsCaseData.SscsCaseDataBuilder sscsCaseDetails) throws JsonProcessingException {
+        wireMock.stubFor(get(urlEqualTo("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId))
+                .withHeader("ServiceAuthorization", new RegexPattern(".*"))
+                .willReturn(okJson(new ObjectMapper().writeValueAsString(SscsCaseDetails.builder()
+                        .id(caseId)
+                        .data(sscsCaseDetails.build())
+                        .build())))
+        );
+    }
+
     public void stubUpdateCase(Long caseId, String caseReference) throws JsonProcessingException {
         wireMock.stubFor(get("/caseworkers/someId/jurisdictions/SSCS/case-types/Benefit/cases/" + caseId + "/event-triggers/uploadDocument/token")
                 .willReturn(okJson(new ObjectMapper().writeValueAsString(StartEventResponse.builder().build()))));
@@ -155,5 +165,26 @@ public class CcdStub extends BaseStub {
                 .replace("{evidenceCreatedDate}", evidenceCreatedDate)
                 .replace("{evidenceUrl}", evidenceUrl);
 
+    }
+
+    public static SscsCaseData.SscsCaseDataBuilder baseCaseData(String caseReference) {
+        return SscsCaseData.builder()
+                .caseReference(caseReference)
+                .onlinePanel(OnlinePanel.builder()
+                        .assignedTo("someJudge")
+                        .build())
+                .appeal(Appeal.builder()
+                        .hearingType("cor")
+                        .appellant(Appellant.builder()
+                                .name(Name.builder()
+                                        .firstName("firstName")
+                                        .lastName("lastName")
+                                        .build())
+                                .identity(Identity.builder()
+                                        .nino("nino")
+                                        .build())
+                                .build())
+                        .benefitType(BenefitType.builder().code("PIP").build())
+                        .build());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/AnswerSubmittedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/AnswerSubmittedEventAction.java
@@ -4,34 +4,24 @@ import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.submitted;
 
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
-import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
+import uk.gov.hmcts.reform.sscscorbackend.service.evidence.EvidenceUploadEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreAnswersPdfService;
 
 @Service
 public class AnswerSubmittedEventAction extends QuestionRoundEndedAction {
 
-    private final QuestionService questionService;
-
-    public AnswerSubmittedEventAction(CorEmailService corEmailService, StoreAnswersPdfService storeAnswersPdfService, EmailMessageBuilder emailMessageBuilder, QuestionService questionService) {
-        super(storeAnswersPdfService, corEmailService, emailMessageBuilder);
-        this.questionService = questionService;
+    public AnswerSubmittedEventAction(CorEmailService corEmailService, StoreAnswersPdfService storeAnswersPdfService, EmailMessageBuilder emailMessageBuilder, EvidenceUploadEmailService evidenceUploadEmailService, QuestionService questionService) {
+        super(storeAnswersPdfService, corEmailService, emailMessageBuilder, evidenceUploadEmailService, questionService);
     }
 
-    public CohEventActionContext handle(Long caseId, String onlineHearingId, SscsCaseDetails sscsCaseDetails) {
-        QuestionRound questions = questionService.getQuestions(onlineHearingId, true);
-
-        boolean questionRoundAnswered = questions.getQuestions().stream()
-                .allMatch(questionSummary -> submitted.equals(questionSummary.getAnswerState()));
-
-        if (questionRoundAnswered) {
-            return super.handle(caseId, onlineHearingId, sscsCaseDetails);
-        }
-        return new CohEventActionContext(null, sscsCaseDetails);
+    @Override
+    protected boolean shouldHandleQuestionRound(QuestionRound questions) {
+        return questions.getQuestions().stream()
+                    .allMatch(questionSummary -> submitted.equals(questionSummary.getAnswerState()));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineElapsedEventAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/actions/DeadlineElapsedEventAction.java
@@ -3,8 +3,11 @@ package uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
+import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
+import uk.gov.hmcts.reform.sscscorbackend.service.evidence.EvidenceUploadEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreAnswersDeadlineElapsedPdfService;
 
 @Service
@@ -14,8 +17,10 @@ public class DeadlineElapsedEventAction extends QuestionRoundEndedAction {
     public DeadlineElapsedEventAction(
             CorEmailService corEmailService,
             StoreAnswersDeadlineElapsedPdfService storeQuestionsPdfService,
-            EmailMessageBuilder emailMessageBuilder) {
-        super(storeQuestionsPdfService, corEmailService, emailMessageBuilder);
+            EmailMessageBuilder emailMessageBuilder,
+            EvidenceUploadEmailService evidenceUploadEmailService,
+            QuestionService questionService) {
+        super(storeQuestionsPdfService, corEmailService, emailMessageBuilder, evidenceUploadEmailService, questionService);
     }
 
     @Override
@@ -26,5 +31,10 @@ public class DeadlineElapsedEventAction extends QuestionRoundEndedAction {
     @Override
     public EventType getCcdEventType() {
         return EventType.COH_QUESTION_DEADLINE_ELAPSED;
+    }
+
+    @Override
+    boolean shouldHandleQuestionRound(QuestionRound questions) {
+        return true;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadController.java
@@ -3,7 +3,9 @@ package uk.gov.hmcts.reform.sscscorbackend.controllers;
 import static org.springframework.http.ResponseEntity.notFound;
 import static org.springframework.http.ResponseEntity.unprocessableEntity;
 
-import io.swagger.annotations.*;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/QuestionSummary.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/QuestionSummary.java
@@ -14,14 +14,16 @@ public class QuestionSummary {
     private final String questionHeaderText;
     private final String questionBodyText;
     private final AnswerState answerState;
+    private final String answeredDate;
     private final String answer;
 
-    public QuestionSummary(String id, int questionOrdinal, String questionHeaderText, String questionBodyText, AnswerState answerState, String answer) {
+    public QuestionSummary(String id, int questionOrdinal, String questionHeaderText, String questionBodyText, AnswerState answerState, String answeredDate, String answer) {
         this.id = id;
         this.questionHeaderText = questionHeaderText;
         this.questionBodyText = questionBodyText;
         this.answerState = answerState;
         this.questionOrdinal = questionOrdinal;
+        this.answeredDate = answeredDate;
         this.answer = answer;
     }
 
@@ -56,6 +58,12 @@ public class QuestionSummary {
     }
 
     @ApiModelProperty(required = false)
+    @JsonProperty(value = "answered_date")
+    public String getAnsweredDate() {
+        return answeredDate;
+    }
+
+    @ApiModelProperty(required = false)
     @JsonProperty(value = "answer")
     public String getAnswer() {
         return answer;
@@ -75,12 +83,13 @@ public class QuestionSummary {
                 Objects.equals(questionHeaderText, that.questionHeaderText) &&
                 Objects.equals(questionBodyText, that.questionBodyText) &&
                 answerState == that.answerState &&
+                Objects.equals(answeredDate, that.answeredDate) &&
                 Objects.equals(answer, that.answer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, questionOrdinal, questionHeaderText, questionBodyText, answerState, answer);
+        return Objects.hash(id, questionOrdinal, questionHeaderText, questionBodyText, answerState, answeredDate, answer);
     }
 
     @Override
@@ -91,6 +100,7 @@ public class QuestionSummary {
                 ", questionHeaderText='" + questionHeaderText + '\'' +
                 ", questionBodyText='" + questionBodyText + '\'' +
                 ", answerState=" + answerState +
+                ", answeredDate='" + answeredDate + '\'' +
                 ", answer='" + answer + '\'' +
                 '}';
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
@@ -168,7 +168,7 @@ public class OnlineHearingService {
                 .map(onlineHearing -> {
                     Name name = sscsCaseDeails.getData().getAppeal().getAppellant().getName();
                     String nameString = name.getFirstName() + " " + name.getLastName();
-                    
+
                     boolean hasFinalDecision = sscsCaseDeails.getData().isCorDecision();
 
                     return new OnlineHearing(

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
@@ -143,6 +143,7 @@ public class QuestionService {
                 cohQuestionReference.getQuestionHeaderText(),
                 cohQuestionReference.getQuestionBodyText(),
                 answerState,
+                getAnswerDate(answers),
                 getAnswer(answers)
         );
     }
@@ -158,6 +159,12 @@ public class QuestionService {
         return getFirstAnswer(answers)
                 .map(CohAnswer::getAnswerText)
                 .orElse("");
+    }
+
+    private String getAnswerDate(List<CohAnswer> answers) {
+        return getFirstAnswer(answers)
+                .flatMap(CohAnswer::getAnsweredDate)
+                .orElse(null);
     }
 
     private Optional<CohAnswer> getFirstAnswer(List<CohAnswer> answers) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilder.java
@@ -6,7 +6,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
-import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionSummary;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.PdfDateUtil;
 
 @Service
@@ -87,10 +87,10 @@ public class EmailMessageBuilder {
                 "Additional evidence submitted by appellant");
     }
 
-    public String getQuestionEvidenceSubmittedMessage(SscsCaseDetails sscsCaseDetails, Question question) {
+    public String getQuestionEvidenceSubmittedMessage(SscsCaseDetails sscsCaseDetails, QuestionSummary question) {
         return buildMessageWithHeading(sscsCaseDetails,
                 "Additional evidence was received by the tribunal for the above appeal on " +
-                        PdfDateUtil.reformatDateTimeToDate(question.getAnswerDate()) +
+                        PdfDateUtil.reformatDateTimeToDate(question.getAnsweredDate()) +
                         ". It was submitted in relation to the question " +
                         question.getQuestionHeaderText(),
                 "Additional evidence submitted in relation to question");

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscscorbackend.service.evidence;
 
 import static java.util.stream.Collectors.toList;
+import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.submitted;
 
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -8,7 +9,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.CorDocument;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentDetails;
-import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionSummary;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.UploadedEvidence;
@@ -38,7 +39,7 @@ public class EvidenceUploadEmailService {
         );
     }
 
-    public void sendToDwp(Question question, List<CorDocument> newEvidence, SscsCaseDetails sscsCaseDetails) {
+    public void sendToDwp(QuestionSummary question, List<CorDocument> newEvidence, SscsCaseDetails sscsCaseDetails) {
         String message = emailMessageBuilder.getQuestionEvidenceSubmittedMessage(sscsCaseDetails, question);
         String subject = "Evidence uploaded (" + sscsCaseDetails.getData().getCaseReference() + ")";
 
@@ -47,6 +48,20 @@ public class EvidenceUploadEmailService {
                 message,
                 subject
         );
+    }
+
+    public void sendQuestionEvidenceToDwp(List<QuestionSummary> questions, SscsCaseDetails sscsCaseDetails) {
+        questions.stream()
+                .filter(questionSummary -> submitted.equals(questionSummary.getAnswerState()))
+                .forEach(question -> {
+                    List<CorDocument> corDocuments = sscsCaseDetails.getData().getCorDocument();
+                    if (corDocuments != null) {
+                        List<CorDocument> corDocumentsForQuestion = corDocuments.stream()
+                                .filter(corDocument -> corDocument.getValue().getQuestionId().equalsIgnoreCase(question.getId()))
+                                .collect(toList());
+                        sendToDwp(question, corDocumentsForQuestion, sscsCaseDetails);
+                    }
+                });
     }
 
     private void sendFileToDwp(List<SscsDocumentDetails> newEvidence, String message, String subject) {

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
@@ -155,9 +155,6 @@ public class EvidenceUploadService {
                         sscsCaseData.setCorDocument(newCorDocumentList);
                         sscsCaseData.setDraftCorDocument(draftCorDocumentsForQuestionId.get(false));
                         ccdService.updateCase(sscsCaseData, ccdCaseId, UPLOAD_COR_DOCUMENT, "SSCS - cor evidence uploaded", UPDATED_SSCS, idamService.getIdamTokens());
-
-                        List<CorDocument> corDocuments = draftCorDocumentsForQuestionId.get(true);
-                        evidenceUploadEmailService.sendToDwp(question, corDocuments, caseDetails);
                     }
                     return true;
                 })

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/DataFixtures.java
@@ -34,7 +34,11 @@ public class DataFixtures {
     }
 
     public static List<QuestionSummary> someQuestionSummaries() {
-        return singletonList(new QuestionSummary("someQuestionId", 1, "someQuestionHeader", "someQuestionBody", draft, "someAnswer"));
+        return singletonList(someQuestionSummary());
+    }
+
+    public static QuestionSummary someQuestionSummary() {
+        return new QuestionSummary("someQuestionId", 1, "someQuestionHeader", "someQuestionBody", draft, "2018-08-08T09:12:12Z","someAnswer");
     }
 
     public static Question someQuestion() {

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/AnswerSubmittedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/AnswerSubmittedEventActionTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionSummary;
 import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
+import uk.gov.hmcts.reform.sscscorbackend.service.evidence.EvidenceUploadEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreAnswersPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
@@ -37,6 +38,7 @@ public class AnswerSubmittedEventActionTest {
     private SscsCaseDetails caseDetails;
     private String someCaseReference;
     private QuestionService questionService;
+    private EvidenceUploadEmailService evidenceUploadEmailService;
 
     @Before
     public void setUp() throws Exception {
@@ -44,8 +46,9 @@ public class AnswerSubmittedEventActionTest {
         storeAnswersPdfService = mock(StoreAnswersPdfService.class);
         emailMessageBuilder = mock(EmailMessageBuilder.class);
         questionService = mock(QuestionService.class);
+        evidenceUploadEmailService = mock(EvidenceUploadEmailService.class);
 
-        answerSubmittedEventAction = new AnswerSubmittedEventAction(corEmailService, storeAnswersPdfService, emailMessageBuilder, questionService);
+        answerSubmittedEventAction = new AnswerSubmittedEventAction(corEmailService, storeAnswersPdfService, emailMessageBuilder, evidenceUploadEmailService, questionService);
         caseId = 123L;
         onlineHearingId = "onlineHearingId";
 
@@ -93,8 +96,8 @@ public class AnswerSubmittedEventActionTest {
 
     private QuestionRound getQuestionRound(AnswerState answerState) {
         List<QuestionSummary> questionSummaries =
-                asList(new QuestionSummary("someQuestionId", 1, "someQuestionHeader", "someQuestionBody", submitted, "someAnswer"),
-                        new QuestionSummary("someQuestionId", 2, "someQuestionHeader", "someQuestionBody", answerState, "someAnswer"));
+                asList(new QuestionSummary("someQuestionId", 1, "someQuestionHeader", "someQuestionBody", submitted, "2018-08-08T09:12:12Z", "someAnswer"),
+                        new QuestionSummary("someQuestionId", 2, "someQuestionHeader", "someQuestionBody", answerState, null,"someAnswer"));
         return new QuestionRound(questionSummaries, now().plusDays(7).format(ISO_LOCAL_DATE_TIME), 0);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/DeadlineElapsedEventActionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/coheventmapper/action/DeadlineElapsedEventActionTest.java
@@ -3,14 +3,18 @@ package uk.gov.hmcts.reform.sscscorbackend.coheventmapper.action;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.sscscorbackend.DataFixtures.someQuestionRound;
 import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.UploadedEvidence.pdf;
 
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscscorbackend.coheventmapper.actions.DeadlineElapsedEventAction;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionRound;
+import uk.gov.hmcts.reform.sscscorbackend.service.QuestionService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
+import uk.gov.hmcts.reform.sscscorbackend.service.evidence.EvidenceUploadEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.CohEventActionContext;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.StoreAnswersDeadlineElapsedPdfService;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.PdfData;
@@ -21,8 +25,10 @@ public class DeadlineElapsedEventActionTest {
         CorEmailService corEmailService = mock(CorEmailService.class);
         StoreAnswersDeadlineElapsedPdfService storeAnswersPdfService = mock(StoreAnswersDeadlineElapsedPdfService.class);
         EmailMessageBuilder emailMessageBuilder = mock(EmailMessageBuilder.class);
+        EvidenceUploadEmailService evidenceUploadEmailService = mock(EvidenceUploadEmailService.class);
+        QuestionService questionService = mock(QuestionService.class);
 
-        DeadlineElapsedEventAction deadlineElapsedEventAction = new DeadlineElapsedEventAction(corEmailService, storeAnswersPdfService, emailMessageBuilder);
+        DeadlineElapsedEventAction deadlineElapsedEventAction = new DeadlineElapsedEventAction(corEmailService, storeAnswersPdfService, emailMessageBuilder, evidenceUploadEmailService, questionService);
 
         String someCaseReference = "someCaseReference";
         SscsCaseDetails caseDetails = SscsCaseDetails.builder()
@@ -35,10 +41,13 @@ public class DeadlineElapsedEventActionTest {
         when(emailMessageBuilder.getAnswerMessage(caseDetails)).thenReturn("some message");
         when(storeAnswersPdfService.storePdf(caseId, onlineHearingId, new PdfData(caseDetails)))
                 .thenReturn(cohEventActionContext);
+        QuestionRound questionRound = someQuestionRound();
+        when(questionService.getQuestions(onlineHearingId, true)).thenReturn(questionRound);
 
         CohEventActionContext result = deadlineElapsedEventAction.handle(caseId, onlineHearingId, caseDetails);
 
         verify(corEmailService).sendFileToDwp(cohEventActionContext, "Appellant has provided information (" + someCaseReference + ")", "some message");
+        verify(evidenceUploadEmailService).sendQuestionEvidenceToDwp(questionRound.getQuestions(), caseDetails);
         assertThat(result, is(cohEventActionContext));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/domain/EvidenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/domain/EvidenceTest.java
@@ -10,7 +10,7 @@ public class EvidenceTest {
     public void getId() {
         Evidence evidence = new Evidence("http://example.com/documents/someId", "someFIleName", "someDate");
         String id = evidence.getId();
-        
+
         assertThat(id, is("someId"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/email/EmailMessageBuilderTest.java
@@ -8,7 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
-import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionSummary;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.util.PdfDateUtil;
 
 public class EmailMessageBuilderTest {
@@ -186,7 +186,7 @@ public class EmailMessageBuilderTest {
 
     @Test
     public void buildQuestionEvidenceSubmitted() {
-        Question question = DataFixtures.someQuestion();
+        QuestionSummary question = DataFixtures.someQuestionSummary();
         String questionHeaderText = question.getQuestionHeaderText();
         String message = new EmailMessageBuilder().getQuestionEvidenceSubmittedMessage(caseDetails, question);
 

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadEmailServiceTest.java
@@ -1,14 +1,18 @@
 package uk.gov.hmcts.reform.sscscorbackend.service.evidence;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.draft;
+import static uk.gov.hmcts.reform.sscscorbackend.domain.AnswerState.submitted;
 import static uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.UploadedEvidence.pdf;
 
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscscorbackend.DataFixtures;
-import uk.gov.hmcts.reform.sscscorbackend.domain.Question;
+import uk.gov.hmcts.reform.sscscorbackend.domain.QuestionSummary;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.CorEmailService;
 import uk.gov.hmcts.reform.sscscorbackend.service.email.EmailMessageBuilder;
 import uk.gov.hmcts.reform.sscscorbackend.service.pdf.data.UploadedEvidence;
@@ -21,6 +25,7 @@ public class EvidenceUploadEmailServiceTest {
     private EmailMessageBuilder emailMessageBuilder;
     private FileDownloader fileDownloader;
     private UploadedEvidence evidenceDescriptionPdf;
+    private EvidenceUploadEmailService evidenceUploadEmailService;
 
     @Before
     public void setUp() {
@@ -30,6 +35,8 @@ public class EvidenceUploadEmailServiceTest {
         emailMessageBuilder = mock(EmailMessageBuilder.class);
         fileDownloader = mock(FileDownloader.class);
         evidenceDescriptionPdf = pdf(new byte[]{2, 4, 6, 0, 1}, "Evidence description");
+
+        evidenceUploadEmailService = new EvidenceUploadEmailService(corEmailService, emailMessageBuilder, fileDownloader);
     }
 
     @Test
@@ -50,7 +57,7 @@ public class EvidenceUploadEmailServiceTest {
         UploadedEvidence expectedFile = mock(UploadedEvidence.class);
         when(fileDownloader.downloadFile(docUrl)).thenReturn(expectedFile);
 
-        new EvidenceUploadEmailService(corEmailService, emailMessageBuilder, fileDownloader).sendToDwp(
+        evidenceUploadEmailService.sendToDwp(
                 evidenceDescriptionPdf,
                 singletonList(sscsDocument),
                 sscsCaseDetails
@@ -76,25 +83,15 @@ public class EvidenceUploadEmailServiceTest {
         String docUrl = "docUrl";
         String fileName = "fileName";
 
-        CorDocument corDocument = CorDocument.builder()
-                .value(CorDocumentDetails.builder()
-                        .document(SscsDocumentDetails.builder()
-                                .documentFileName(fileName)
-                                .documentLink(DocumentLink.builder()
-                                        .documentBinaryUrl(docUrl)
-                                        .build())
-                                .build())
-                        .build())
-                .build();
+        CorDocument corDocument = createCorDocument(docUrl, fileName, "someQuestionId");
 
-
-        Question question = DataFixtures.someQuestion();
+        QuestionSummary question = DataFixtures.someQuestionSummary();
 
         when(emailMessageBuilder.getQuestionEvidenceSubmittedMessage(sscsCaseDetails, question)).thenReturn(message);
         UploadedEvidence expectedFile = mock(UploadedEvidence.class);
         when(fileDownloader.downloadFile(docUrl)).thenReturn(expectedFile);
 
-        new EvidenceUploadEmailService(corEmailService, emailMessageBuilder, fileDownloader).sendToDwp(
+        evidenceUploadEmailService.sendToDwp(
                 question,
                 singletonList(corDocument),
                 sscsCaseDetails
@@ -106,5 +103,105 @@ public class EvidenceUploadEmailServiceTest {
                 eq("Evidence uploaded (" + caseReference + ")"),
                 eq(message)
         );
+    }
+
+    @Test
+    public void sendsAllQuestionsEvidence() {
+        String docUrl1 = "docUrl1";
+        String questionId1 = "someQuestionId1";
+        String questionId2 = "someQuestionId2";
+        String questionIdWithNoEvidence = "questionIdWithNoEvidence";
+        List<QuestionSummary> questionSummaries = asList(
+                new QuestionSummary(questionId1, 1, "someQuestionHeader", "someQuestionBody", submitted, "2018-08-08T09:12:12Z", "someAnswer"),
+                new QuestionSummary(questionId2, 2, "someQuestionHeader", "someQuestionBody", submitted, "2018-08-08T09:12:12Z", "someAnswer"),
+                new QuestionSummary(questionIdWithNoEvidence, 3, "someQuestionHeader", "someQuestionBody", submitted, "2018-08-08T09:12:12Z", "someAnswer")
+        );
+        CorDocument corDocument1 = createCorDocument(docUrl1, "fileName1", questionId1);
+
+        String docUrl2 = "docUrl2";
+        CorDocument corDocument2 = createCorDocument(docUrl2, "fileName2", questionId2);
+
+        List<CorDocument> corDocuments = asList(corDocument1, corDocument2);
+        SscsCaseDetails sscsCaseDetails = createSscsCaseDetails(corDocuments);
+
+        UploadedEvidence expectedFile = mock(UploadedEvidence.class);
+        when(fileDownloader.downloadFile(docUrl1)).thenReturn(expectedFile);
+        UploadedEvidence expectedFile2 = mock(UploadedEvidence.class);
+        when(fileDownloader.downloadFile(docUrl2)).thenReturn(expectedFile2);
+        String message1 = "some message1";
+        when(emailMessageBuilder.getQuestionEvidenceSubmittedMessage(sscsCaseDetails, questionSummaries.get(0))).thenReturn(message1);
+        String message2 = "some message2";
+        when(emailMessageBuilder.getQuestionEvidenceSubmittedMessage(sscsCaseDetails, questionSummaries.get(1))).thenReturn(message2);
+
+        evidenceUploadEmailService.sendQuestionEvidenceToDwp(questionSummaries, sscsCaseDetails);
+
+        verify(fileDownloader).downloadFile(docUrl1);
+        verify(fileDownloader).downloadFile(docUrl2);
+        verify(corEmailService, times(1)).sendFileToDwp(
+                eq(expectedFile),
+                eq("Evidence uploaded (" + caseReference + ")"),
+                eq(message1)
+        );
+        verify(corEmailService, times(1)).sendFileToDwp(
+                eq(expectedFile2),
+                eq("Evidence uploaded (" + caseReference + ")"),
+                eq(message2)
+        );
+    }
+
+    @Test
+    public void doesNotSendUnsubmittedQuestions() {
+        String questionId1 = "someQuestionId1";
+
+        List<QuestionSummary> questionSummaries = singletonList(
+                new QuestionSummary(questionId1, 1, "someQuestionHeader", "someQuestionBody", draft, "2018-08-08T09:12:12Z", "someAnswer")
+        );
+
+        SscsCaseDetails sscsCaseDetails = createSscsCaseDetails(singletonList(createCorDocument("docUrl1", "fileName1", questionId1)));
+
+
+        evidenceUploadEmailService.sendQuestionEvidenceToDwp(questionSummaries, sscsCaseDetails);
+
+        verifyZeroInteractions(fileDownloader);
+        verifyZeroInteractions(corEmailService);
+    }
+
+    @Test
+    public void canHandleNoEvidenceToSendToDwp() {
+        String questionId1 = "someQuestionId1";
+
+        List<QuestionSummary> questionSummaries = singletonList(
+                new QuestionSummary(questionId1, 1, "someQuestionHeader", "someQuestionBody", submitted, "2018-08-08T09:12:12Z", "someAnswer")
+        );
+
+        SscsCaseDetails sscsCaseDetails = createSscsCaseDetails(null);
+
+
+        evidenceUploadEmailService.sendQuestionEvidenceToDwp(questionSummaries, sscsCaseDetails);
+
+        verifyZeroInteractions(fileDownloader);
+        verifyZeroInteractions(corEmailService);
+    }
+
+    private SscsCaseDetails createSscsCaseDetails(List<CorDocument> corDocument) {
+        return SscsCaseDetails.builder().data(SscsCaseData.builder()
+                .caseReference(caseReference)
+                .corDocument(corDocument)
+                .build()
+        ).build();
+    }
+
+    private CorDocument createCorDocument(String docUrl1, String fileName, String questionId1) {
+        return CorDocument.builder()
+                .value(CorDocumentDetails.builder()
+                        .questionId(questionId1)
+                        .document(SscsDocumentDetails.builder()
+                                .documentFileName(fileName)
+                                .documentLink(DocumentLink.builder()
+                                        .documentBinaryUrl(docUrl1)
+                                        .build())
+                                .build())
+                        .build())
+                .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadServiceTest.java
@@ -200,7 +200,6 @@ public class EvidenceUploadServiceTest {
         boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, question);
 
         assertThat(submittedEvidence, is(true));
-        verify(evidenceUploadEmailService).sendToDwp(question, draftCorDocument, sscsCaseDetails);
         verify(ccdService).updateCase(
                 and(hasCorDocument(0, someQuestionId, documentUrl, fileName), doesNotHaveDraftCorDocuments()),
                 eq(someCcdCaseId),
@@ -231,7 +230,6 @@ public class EvidenceUploadServiceTest {
         boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, question);
 
         assertThat(submittedEvidence, is(true));
-        verify(evidenceUploadEmailService).sendToDwp(question, draftCorDocument, sscsCaseDetails);
         verify(ccdService).updateCase(
                 and(hasCorDocument(originalNumberOfSscsDocuments, someQuestionId, documentUrl, fileName), doesNotHaveDraftCorDocuments()),
                 eq(someCcdCaseId),
@@ -264,7 +262,6 @@ public class EvidenceUploadServiceTest {
         boolean submittedEvidence = evidenceUploadService.submitQuestionEvidence(someOnlineHearingId, question);
 
         assertThat(submittedEvidence, is(true));
-        verify(evidenceUploadEmailService).sendToDwp(question, asList(expectedCorDocument), sscsCaseDetails);
         verify(ccdService).updateCase(
                 and(hasCorDocument(0, someQuestionId, expectedUrl, expectedFileName), hasDraftCorDocument(0, draftQuestionId, draftDocumentUrl, draftFileName)),
                 eq(someCcdCaseId),

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/PdfSummaryBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/pdf/PdfSummaryBuilderTest.java
@@ -42,7 +42,7 @@ public class PdfSummaryBuilderTest {
         ));
 
         List<PdfQuestionRound> pdfQuestionRounds = new PdfSummaryBuilder().buildPdfSummary(cohConversations, somePdfAppealDetails()).getQuestionRounds();
-        
+
         assertThat(pdfQuestionRounds, is(asList(
                 new PdfQuestionRound(asList(
                         new PdfQuestion("questionHeader-1-1", "questionBody-1-1", "answerText-1-1", AnswerState.submitted, "5 June 2018", "5 July 2018"),


### PR DESCRIPTION
We were sending evidence to DWP for questions when the question was
submitted. This might be before the panel can see the evidence as they
can only see it when it appears in JUI. The appeal will only appear
in JUI once all the questions have been answered or the deadline
expires.

Changed code to only send evidence to DWP once all the questions
have been answered or the deadline expires.

https://tools.hmcts.net/jira/browse/SSCS-5546

```
[ ] Yes
[X] No
```
