### PR TITLE
Fix answered date for question summaries

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CohStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/stubs/CohStub.java
@@ -80,7 +80,7 @@ public class CohStub extends BaseStub {
             "              \"answer_id\": \"string\",\n" +
             "              \"answer_text\": \"string\",\n" +
             "              \"current_answer_state\": {\n" +
-            "                \"state_datetime\": \"string\",\n" +
+            "                \"state_datetime\": \"2019-05-28T15:19:40Z\",\n" +
             "                \"state_desc\": \"string\",\n" +
             "                \"state_name\": \"{answer_state}\"\n" +
             "              },\n" +

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/QuestionService.java
@@ -163,7 +163,8 @@ public class QuestionService {
 
     private String getAnswerDate(List<CohAnswer> answers) {
         return getFirstAnswer(answers)
-                .flatMap(CohAnswer::getAnsweredDate)
+                .filter(answer -> "answer_submitted".equals(answer.getCurrentAnswerState().getStateName()))
+                .map(answer -> answer.getCurrentAnswerState().getStateDateTime())
                 .orElse(null);
     }
 


### PR DESCRIPTION
Have to get the answered date form the current answer
state not the answer history.

https://tools.hmcts.net/jira/browse/SSCS-5546

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
