### PR TITLE
Allow null SC number

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/OnlineHearing.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/OnlineHearing.java
@@ -49,7 +49,7 @@ public class OnlineHearing {
         return appellantName;
     }
 
-    @ApiModelProperty(example = "SC112/233", required = true)
+    @ApiModelProperty(example = "SC112/233")
     @JsonProperty(value = "case_reference")
     public String getCaseReference() {
         return caseReference;


### PR DESCRIPTION
We didn't used to send out a link to COR until a judge had issued
a question. This was after the SC number had been set on the case.
Therefore we always expected an SC number when we loaded the case.
Now for MYA you will get a link to MYA just after submission and
the case will not get an SC number until later. Allow caseRef which
is the sc number to not be required in the api.

In future we will show the case id but that will be a story when
the business is ready.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
