### PR TITLE
Sscs 6098 update coversheet

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.ResponseEntity.notFound;
 import static org.springframework.http.ResponseEntity.unprocessableEntity;
 
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.List;
@@ -183,20 +184,20 @@ public class EvidenceUploadController {
 
     @ApiOperation(value = "Get evidence cover sheet",
             notes = "Generates a PDF file that can be printed out and added as a cover sheet to evidence that is to be " +
-                    "posted in."
+                    "posted in. Can use either the CCD case id which is a number or online hearing id which is a GUUID."
     )
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "A PDF cover sheet"),
             @ApiResponse(code = 404, message = "No online hearing found with online hearing id")
     })
     @GetMapping(
-            value = "{onlineHearingId}/evidence/coversheet",
+            value = "{identifier}/evidence/coversheet",
             produces = MediaType.APPLICATION_PDF_VALUE
     )
     public ResponseEntity<ByteArrayResource> getCoverSheet(
-            @PathVariable("onlineHearingId") String onlineHearingId
+            @ApiParam(value = "either the online hearing or CCD case id", example = "xxxxx-xxxx-xxxx-xxxx") @PathVariable("identifier") String identifier
     ) {
-        Optional<byte[]> coverSheet = coversheetService.createCoverSheet(onlineHearingId);
+        Optional<byte[]> coverSheet = coversheetService.createCoverSheet(identifier);
         return coverSheet.map(pdfBytes ->
                 ResponseEntity.ok()
                         .header("Content-Disposition", "inline; filename=evidence_cover_sheet.pdf")

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/HearingArrangements.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/domain/HearingArrangements.java
@@ -60,7 +60,7 @@ public class HearingArrangements {
         return disabledAccessRequired;
     }
 
-    @ApiModelProperty(example = "true", required = true)
+    @ApiModelProperty(example = "some other arrangements", required = true)
     @JsonProperty(value = "other_arrangements")
     public String getOtherArrangements() {
         return otherArrangements;

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/CoversheetService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/CoversheetService.java
@@ -18,16 +18,20 @@ public class CoversheetService {
     private final OnlineHearingService onlineHearingService;
     private final PdfService pdfService;
     private final String template;
+    private final String hmctsImg;
     private final CcdService ccdService;
     private final IdamService idamService;
 
     public CoversheetService(
             OnlineHearingService onlineHearingService,
             @Qualifier("docmosisPdfService") PdfService pdfService,
-            @Value("${evidenceCoverSheet.docmosis.template}") String template, CcdService ccdService, IdamService idamService) {
+            @Value("${evidenceCoverSheet.docmosis.template}") String template,
+            @Value("${evidenceCoverSheet.docmosis.hmctsImgVal}") String hmctsImg,
+            CcdService ccdService, IdamService idamService) {
         this.onlineHearingService = onlineHearingService;
         this.pdfService = pdfService;
         this.template = template;
+        this.hmctsImg = hmctsImg;
         this.ccdService = ccdService;
         this.idamService = idamService;
     }
@@ -48,7 +52,8 @@ public class CoversheetService {
                             address.getLine2(),
                             address.getTown(),
                             address.getCounty(),
-                            address.getPostcode()
+                            address.getPostcode(),
+                            hmctsImg
                     );
 
                     return pdfService.createPdf(pdfCoverSheet, template);

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/CoversheetService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/CoversheetService.java
@@ -1,11 +1,15 @@
 package uk.gov.hmcts.reform.sscscorbackend.service.coversheet;
 
 import java.util.Optional;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscscorbackend.service.OnlineHearingService;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
@@ -14,18 +18,26 @@ public class CoversheetService {
     private final OnlineHearingService onlineHearingService;
     private final PdfService pdfService;
     private final String template;
+    private final CcdService ccdService;
+    private final IdamService idamService;
 
     public CoversheetService(
             OnlineHearingService onlineHearingService,
             @Qualifier("docmosisPdfService") PdfService pdfService,
-            @Value("${evidenceCoverSheet.docmosis.template}") String template) {
+            @Value("${evidenceCoverSheet.docmosis.template}") String template, CcdService ccdService, IdamService idamService) {
         this.onlineHearingService = onlineHearingService;
         this.pdfService = pdfService;
         this.template = template;
+        this.ccdService = ccdService;
+        this.idamService = idamService;
     }
 
-    public Optional<byte[]> createCoverSheet(String onlineHearingId) {
-        return onlineHearingService.getCcdCase(onlineHearingId)
+    public Optional<byte[]> createCoverSheet(String identifier) {
+        Optional<SscsCaseDetails> sscsCaseDetails = !NumberUtils.isDigits(identifier)
+                ? onlineHearingService.getCcdCase(identifier) :
+                Optional.ofNullable(ccdService.getByCaseId(Long.parseLong(identifier), idamService.getIdamTokens()));
+
+        return sscsCaseDetails
                 .map(sscsCase -> {
                     SscsCaseData sscsCaseData = sscsCase.getData();
                     Address address = sscsCaseData.getAppeal().getAppellant().getAddress();

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/PdfCoverSheet.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/PdfCoverSheet.java
@@ -7,7 +7,7 @@ public class PdfCoverSheet {
     @JsonProperty("case_id")
     private final String caseId;
     @JsonProperty("name")
-    private final String name;
+    private String name;
     @JsonProperty("address_line1")
     private final String addressLine1;
     @JsonProperty("address_line2")
@@ -18,6 +18,8 @@ public class PdfCoverSheet {
     private final String addressCounty;
     @JsonProperty("address_postcode")
     private final String addressPostcode;
+    @JsonProperty("hmcts")
+    private final String hmcts;
 
     public PdfCoverSheet(String caseId,
                          String name,
@@ -25,7 +27,8 @@ public class PdfCoverSheet {
                          String addressLine2,
                          String addressTown,
                          String addressCounty,
-                         String addressPostcode) {
+                         String addressPostcode,
+                         String hmcts) {
         this.caseId = caseId;
         this.name = name;
         this.addressLine1 = addressLine1;
@@ -33,6 +36,7 @@ public class PdfCoverSheet {
         this.addressTown = addressTown;
         this.addressCounty = addressCounty;
         this.addressPostcode = addressPostcode;
+        this.hmcts = hmcts;
     }
 
     @Override
@@ -50,11 +54,12 @@ public class PdfCoverSheet {
                 Objects.equals(addressLine2, that.addressLine2) &&
                 Objects.equals(addressTown, that.addressTown) &&
                 Objects.equals(addressCounty, that.addressCounty) &&
-                Objects.equals(addressPostcode, that.addressPostcode);
+                Objects.equals(addressPostcode, that.addressPostcode) &&
+                Objects.equals(hmcts, that.hmcts);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(caseId, name, addressLine1, addressLine2, addressTown, addressCounty, addressPostcode);
+        return Objects.hash(caseId, name, addressLine1, addressLine2, addressTown, addressCounty, addressPostcode, hmcts);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -88,6 +88,7 @@ evidenceDescription:
 evidenceCoverSheet:
   docmosis:
     template: TB-SCS-GNO-ENG-00012.docx
+    hmctsImgVal: "[userImage:hmcts.png]"
 
 
 appeal:

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/CoversheetServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/CoversheetServiceTest.java
@@ -25,6 +25,7 @@ public class CoversheetServiceTest {
     private CcdService ccdService;
     private IdamService idamService;
     private IdamTokens idamTokens;
+    private String hmctsImg;
 
     @Before
     public void setUp() {
@@ -36,6 +37,7 @@ public class CoversheetServiceTest {
         idamService = mock(IdamService.class);
         idamTokens = IdamTokens.builder().build();
         when(idamService.getIdamTokens()).thenReturn(idamTokens);
+        hmctsImg = "hmcts.img";
     }
 
     @Test
@@ -44,11 +46,11 @@ public class CoversheetServiceTest {
                 .thenReturn(Optional.of(createSscsCaseDetails()));
 
         byte[] pdf = {2, 4, 6, 0, 1};
-        PdfCoverSheet pdfSummary = new PdfCoverSheet("12345", "firstname lastname", "line1", "line2", "town", "county", "postcode");
+        PdfCoverSheet pdfSummary = new PdfCoverSheet("12345", "firstname lastname", "line1", "line2", "town", "county", "postcode", hmctsImg);
         when(pdfService.createPdf(pdfSummary, template)).thenReturn(pdf);
 
         Optional<byte[]> pdfOptional =
-                new CoversheetService(onlineHearingService, pdfService, template, ccdService, idamService).createCoverSheet(onlineHearingId);
+                new CoversheetService(onlineHearingService, pdfService, template, hmctsImg, ccdService, idamService).createCoverSheet(onlineHearingId);
 
         assertThat(pdfOptional.isPresent(), is(true));
         assertThat(pdfOptional.get(), is(pdf));
@@ -59,7 +61,7 @@ public class CoversheetServiceTest {
         when(onlineHearingService.getCcdCase(onlineHearingId)).thenReturn(Optional.empty());
 
         Optional<byte[]> pdfOptional =
-                new CoversheetService(onlineHearingService, pdfService, template, ccdService, idamService).createCoverSheet(onlineHearingId);
+                new CoversheetService(onlineHearingService, pdfService, template, hmctsImg, ccdService, idamService).createCoverSheet(onlineHearingId);
 
         assertThat(pdfOptional.isPresent(), is(false));
     }
@@ -69,11 +71,11 @@ public class CoversheetServiceTest {
         when(ccdService.getByCaseId(caseId, idamTokens)).thenReturn(createSscsCaseDetails());
 
         byte[] pdf = {2, 4, 6, 0, 1};
-        PdfCoverSheet pdfSummary = new PdfCoverSheet("12345", "firstname lastname", "line1", "line2", "town", "county", "postcode");
+        PdfCoverSheet pdfSummary = new PdfCoverSheet("12345", "firstname lastname", "line1", "line2", "town", "county", "postcode", hmctsImg);
         when(pdfService.createPdf(pdfSummary, template)).thenReturn(pdf);
 
         Optional<byte[]> pdfOptional =
-                new CoversheetService(onlineHearingService, pdfService, template, ccdService, idamService).createCoverSheet(caseId + "");
+                new CoversheetService(onlineHearingService, pdfService, template, hmctsImg, ccdService, idamService).createCoverSheet(caseId + "");
 
         assertThat(pdfOptional.isPresent(), is(true));
         assertThat(pdfOptional.get(), is(pdf));
@@ -84,7 +86,7 @@ public class CoversheetServiceTest {
         when(ccdService.getByCaseId(caseId, idamTokens)).thenReturn(null);
 
         Optional<byte[]> pdfOptional =
-                new CoversheetService(onlineHearingService, pdfService, template, ccdService, idamService).createCoverSheet(onlineHearingId);
+                new CoversheetService(onlineHearingService, pdfService, template, hmctsImg, ccdService, idamService).createCoverSheet(onlineHearingId);
 
         assertThat(pdfOptional.isPresent(), is(false));
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/CoversheetServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/coversheet/CoversheetServiceTest.java
@@ -9,15 +9,22 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscscorbackend.service.OnlineHearingService;
 import uk.gov.hmcts.reform.sscscorbackend.thirdparty.pdfservice.PdfService;
 
 public class CoversheetServiceTest {
 
     private String onlineHearingId;
+    private long caseId = 1234567890L;
     private OnlineHearingService onlineHearingService;
     private PdfService pdfService;
     private String template;
+    private CcdService ccdService;
+    private IdamService idamService;
+    private IdamTokens idamTokens;
 
     @Before
     public void setUp() {
@@ -25,6 +32,10 @@ public class CoversheetServiceTest {
         onlineHearingService = mock(OnlineHearingService.class);
         pdfService = mock(PdfService.class);
         template = "template";
+        ccdService = mock(CcdService.class);
+        idamService = mock(IdamService.class);
+        idamTokens = IdamTokens.builder().build();
+        when(idamService.getIdamTokens()).thenReturn(idamTokens);
     }
 
     @Test
@@ -37,7 +48,7 @@ public class CoversheetServiceTest {
         when(pdfService.createPdf(pdfSummary, template)).thenReturn(pdf);
 
         Optional<byte[]> pdfOptional =
-                new CoversheetService(onlineHearingService, pdfService, template).createCoverSheet(onlineHearingId);
+                new CoversheetService(onlineHearingService, pdfService, template, ccdService, idamService).createCoverSheet(onlineHearingId);
 
         assertThat(pdfOptional.isPresent(), is(true));
         assertThat(pdfOptional.get(), is(pdf));
@@ -48,7 +59,32 @@ public class CoversheetServiceTest {
         when(onlineHearingService.getCcdCase(onlineHearingId)).thenReturn(Optional.empty());
 
         Optional<byte[]> pdfOptional =
-                new CoversheetService(onlineHearingService, pdfService, template).createCoverSheet(onlineHearingId);
+                new CoversheetService(onlineHearingService, pdfService, template, ccdService, idamService).createCoverSheet(onlineHearingId);
+
+        assertThat(pdfOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void canLoadCcdCaseByCaseIdAndProducePdf() {
+        when(ccdService.getByCaseId(caseId, idamTokens)).thenReturn(createSscsCaseDetails());
+
+        byte[] pdf = {2, 4, 6, 0, 1};
+        PdfCoverSheet pdfSummary = new PdfCoverSheet("12345", "firstname lastname", "line1", "line2", "town", "county", "postcode");
+        when(pdfService.createPdf(pdfSummary, template)).thenReturn(pdf);
+
+        Optional<byte[]> pdfOptional =
+                new CoversheetService(onlineHearingService, pdfService, template, ccdService, idamService).createCoverSheet(caseId + "");
+
+        assertThat(pdfOptional.isPresent(), is(true));
+        assertThat(pdfOptional.get(), is(pdf));
+    }
+
+    @Test
+    public void cannotLoadCcdCaseByCaseId() {
+        when(ccdService.getByCaseId(caseId, idamTokens)).thenReturn(null);
+
+        Optional<byte[]> pdfOptional =
+                new CoversheetService(onlineHearingService, pdfService, template, ccdService, idamService).createCoverSheet(onlineHearingId);
 
         assertThat(pdfOptional.isPresent(), is(false));
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/DocmosisPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/thirdparty/pdfservice/DocmosisPdfServiceTest.java
@@ -33,9 +33,10 @@ public class DocmosisPdfServiceTest {
         expectedPlaceholders.put("address_town", "addressTown");
         expectedPlaceholders.put("address_county", "addressCounty");
         expectedPlaceholders.put("address_postcode", "addressPostcode");
+        expectedPlaceholders.put("hmcts", "hmcts.img");
 
         pdfCoverSheet = new PdfCoverSheet(
-                "caseId", "name", "addressLine1", "addressLine2", "addressTown", "addressCounty", "addressPostcode"
+                "caseId", "name", "addressLine1", "addressLine2", "addressTown", "addressCounty", "addressPostcode", "hmcts.img"
         );
         docmosisPdfGenerationService = mock(DocmosisPdfGenerationService.class);
     }


### PR DESCRIPTION
Update coversheet endpoint so you can pass in either the online hearing id or the CCD case id. This needed to change as for MYA you might not have an online hearing id.

Also added the HMCTS logo to the coversheet. 

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-6098

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
