### PR TITLE
SSCS-6334 Allow us to add evidence and statements by Case Id

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/ListQuestionsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/ListQuestionsTest.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.reform.sscscorbackend.thirdparty.coh.api.CohQuestionReferenc
 public class ListQuestionsTest extends BaseIntegrationTest {
     @Test
     public void getQuestion() {
-        String hearingId = "1";
+        String hearingId = "xxx1";
         String deadlineExpiryDate = now().plusDays(7).format(ISO_LOCAL_DATE_TIME);
         CohQuestionReference firstQuestionSummary = new CohQuestionReference(
                 "first-id", 1, "first question", "first question body", deadlineExpiryDate, someCohAnswers("answer_drafted")

--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscscorbackend/QuestionTest.java
@@ -25,7 +25,7 @@ public class QuestionTest extends BaseIntegrationTest {
 
     @Test
     public void getQuestion() {
-        String hearingId = "1";
+        String hearingId = "xxx1";
         String questionId = "1";
         cohStub.stubGetQuestion(hearingId, questionId, QUESTION_HEADER, QUESTION_BODY);
         ZonedDateTime answerDate = ZonedDateTime.now();
@@ -95,7 +95,7 @@ public class QuestionTest extends BaseIntegrationTest {
 
     @Test
     public void submitAnAnswerToAQuestion() throws JsonProcessingException {
-        String hearingId = "1";
+        String hearingId = "xxx1";
         String questionId = "1";;
         String answerId = UUID.randomUUID().toString();
         String answer = "answer";
@@ -121,7 +121,7 @@ public class QuestionTest extends BaseIntegrationTest {
 
     @Test
     public void extendQuestionRoundDeadline() {
-        String hearingId = "1";
+        String hearingId = "xxx1";
         cohStub.stubExtendQuestionRoundDeadline(hearingId);
         String deadlineExpiryDate = now().plusDays(7).format(ISO_LOCAL_DATE_TIME);
         CohQuestionReference questionSummary = new CohQuestionReference(

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/EvidenceUploadController.java
@@ -39,11 +39,10 @@ public class EvidenceUploadController {
         this.coversheetService = coversheetService;
     }
 
-    @ApiOperation(value = "Upload COR evidence",
-            notes = "Uploads evidence for a COR appeal which will be held in a draft state against the case that is not " +
+    @ApiOperation(value = "Upload evidence",
+            notes = "Uploads evidence for an appeal which will be held in a draft state against the case that is not " +
                     "visible by a caseworker in CCD. You will need to submit the evidence for it to be visbale in CCD " +
-                    "by a caseworker. You need to have an appeal in CCD and an online hearing in COH that references " +
-                    "the appeal in CCD."
+                    "by a caseworker. You need to have an appeal in CCD."
     )
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Evidence has been added to the appeal"),
@@ -51,16 +50,16 @@ public class EvidenceUploadController {
             @ApiResponse(code = 422, message = "The file cannot be added to the document store")
     })
     @RequestMapping(
-            value = "{onlineHearingId}/evidence",
+            value = "{identifier}/evidence",
             method = RequestMethod.PUT,
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     public ResponseEntity<Evidence> uploadEvidence(
-            @PathVariable("onlineHearingId") String onlineHearingId,
+            @ApiParam(value = "either the online hearing or CCD case id", example = "xxxxx-xxxx-xxxx-xxxx") @PathVariable("identifier") String identifier,
             @RequestParam("file") MultipartFile file
     ) {
-        return uploadEvidence(() -> evidenceUploadService.uploadDraftHearingEvidence(onlineHearingId, file));
+        return uploadEvidence(() -> evidenceUploadService.uploadDraftHearingEvidence(identifier, file));
     }
 
     @ApiOperation(value = "Upload COR evidence to a question",
@@ -104,14 +103,14 @@ public class EvidenceUploadController {
             @ApiResponse(code = 200, message = "List of draft evidence")
     })
     @RequestMapping(
-            value = "{onlineHearingId}/evidence",
+            value = "{identifier}/evidence",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     public ResponseEntity<List<Evidence>> listDraftEvidence(
-            @PathVariable("onlineHearingId") String onlineHearingId
+            @PathVariable("identifier") String identifier
     ) {
-        return ResponseEntity.ok(evidenceUploadService.listDraftHearingEvidence(onlineHearingId));
+        return ResponseEntity.ok(evidenceUploadService.listDraftHearingEvidence(identifier));
     }
 
     @ApiOperation(value = "Delete COR evidence",
@@ -124,15 +123,15 @@ public class EvidenceUploadController {
     })
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     @RequestMapping(
-            value = "{onlineHearingId}/evidence/{evidenceId}",
+            value = "{identifier}/evidence/{evidenceId}",
             method = RequestMethod.DELETE,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     public ResponseEntity deleteEvidence(
-            @PathVariable("onlineHearingId") String onlineHearingId,
+            @ApiParam(value = "either the online hearing or CCD case id", example = "xxxxx-xxxx-xxxx-xxxx")@PathVariable("identifier") String identifier,
             @PathVariable("evidenceId") String evidenceId
     ) {
-        boolean hearingFound = evidenceUploadService.deleteDraftHearingEvidence(onlineHearingId, evidenceId);
+        boolean hearingFound = evidenceUploadService.deleteDraftHearingEvidence(identifier, evidenceId);
         return hearingFound ? ResponseEntity.noContent().build() : notFound().build();
     }
 
@@ -170,15 +169,15 @@ public class EvidenceUploadController {
             @ApiResponse(code = 404, message = "No online hearing found with online hearing id")
     })
     @RequestMapping(
-            value = "{onlineHearingId}/evidence",
+            value = "{identifier}/evidence",
             method = RequestMethod.POST,
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     public ResponseEntity submitEvidence(
-            @PathVariable("onlineHearingId") String onlineHearingId,
+            @PathVariable("identifier") String identifier,
             @RequestBody EvidenceDescription description
     ) {
-        boolean evidenceSubmitted = evidenceUploadService.submitHearingEvidence(onlineHearingId, description);
+        boolean evidenceSubmitted = evidenceUploadService.submitHearingEvidence(identifier, description);
         return evidenceSubmitted ? ResponseEntity.noContent().build() : notFound().build();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/StatementController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/controllers/StatementController.java
@@ -23,23 +23,23 @@ public class StatementController {
     }
 
     @ApiOperation(value = "Upload COR personal statement",
-            notes = "Uploads a personal statement for a COR appeal. You need to have an appeal in CCD and an online hearing in COH " +
-                    "that references the appeal in CCD. The statement is saved as a piece of evidence for the case in CCD as a PDF."
+            notes = "Uploads a personal statement for a COR appeal. You need to have an appeal in CCD. " +
+                    "The statement is saved as a piece of evidence for the case in CCD as a PDF."
     )
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Statement has been added to the appeal"),
             @ApiResponse(code = 404, message = "No online hearing found with online hearing id")
     })
     @PostMapping(
-            value = "/{onlineHearingId}/statement",
+            value = "/{identifier}/statement",
             produces = MediaType.APPLICATION_JSON_UTF8_VALUE
     )
     public ResponseEntity uploadStatement(
-            @PathVariable("onlineHearingId") String onlineHearingId,
+            @PathVariable("identifier") String identifier,
             @RequestBody Statement statement) {
 
         return appellantStatementService
-                .handleAppellantStatement(onlineHearingId, statement)
+                .handleAppellantStatement(identifier, statement)
                 .map(handled -> ResponseEntity.noContent().build())
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementService.java
@@ -25,11 +25,11 @@ public class AppellantStatementService {
         this.appellantStatementEmailService = appellantStatementEmailService;
     }
 
-    public Optional<CohEventActionContext> handleAppellantStatement(String onlineHearingId, Statement statement) {
-        return onlineHearingService.getCcdCase(onlineHearingId).map(caseDetails -> {
+    public Optional<CohEventActionContext> handleAppellantStatement(String identifier, Statement statement) {
+        return onlineHearingService.getCcdCaseByIdentifier(identifier).map(caseDetails -> {
             CohEventActionContext cohEventActionContext = storeAppellantStatementService.storePdf(
                     caseDetails.getId(),
-                    onlineHearingId,
+                    identifier,
                     new AppellantStatementPdfData(caseDetails, statement)
             );
             appellantStatementEmailService.sendEmail(cohEventActionContext);

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingService.java
@@ -8,6 +8,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -110,6 +111,12 @@ public class OnlineHearingService {
     public Optional<Long> getCcdCaseId(String onlineHearingId) {
         CohOnlineHearing onlineHearing = cohClient.getOnlineHearing(onlineHearingId);
         return (onlineHearing != null) ? Optional.of(onlineHearing.getCcdCaseId()) : Optional.empty();
+    }
+
+    public Optional<SscsCaseDetails> getCcdCaseByIdentifier(String identifier) {
+        return !NumberUtils.isDigits(identifier)
+                ? getCcdCase(identifier) :
+                Optional.ofNullable(ccdService.getByCaseId(Long.parseLong(identifier), idamService.getIdamTokens()));
     }
 
     public Optional<SscsCaseDetails> getCcdCase(String onlineHearingId) {

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/AppellantStatementServiceTest.java
@@ -47,7 +47,7 @@ public class AppellantStatementServiceTest {
     @Test
     public void findsOnlineHearing() {
         long id = 1234L;
-        when(onlineHearingService.getCcdCase(someOnlineHearing)).thenReturn(Optional.of(SscsCaseDetails.builder().id(id).build()));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearing)).thenReturn(Optional.of(SscsCaseDetails.builder().id(id).build()));
         when(storeAppellantStatementService.storePdf(eq(id), eq(someOnlineHearing), any(AppellantStatementPdfData.class)))
                 .thenReturn(mock(CohEventActionContext.class));
         Optional handled = appellantStatementService.handleAppellantStatement(someOnlineHearing, someStatement());
@@ -58,7 +58,7 @@ public class AppellantStatementServiceTest {
     @Test
     public void generatesAndSavesPdf() {
         long id = 1234L;
-        when(onlineHearingService.getCcdCase(someOnlineHearing)).thenReturn(Optional.of(SscsCaseDetails.builder().id(id).build()));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearing)).thenReturn(Optional.of(SscsCaseDetails.builder().id(id).build()));
         CohEventActionContext cohEventActionContext = mock(CohEventActionContext.class);
         when(storeAppellantStatementService.storePdf(eq(id), eq(someOnlineHearing), any(AppellantStatementPdfData.class)))
                 .thenReturn(cohEventActionContext);

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/OnlineHearingServiceTest.java
@@ -207,6 +207,31 @@ public class OnlineHearingServiceTest {
         underTest.getCcdCase(onlineHearingId);
     }
 
+    @Test
+    public void getsACcdCaseByIdentifierFromHearingId() {
+        String onlineHearingId = "someOnlineHearingId";
+        CohOnlineHearing cohOnlineHearing = someCohOnlineHearing();
+        when(cohService.getOnlineHearing(onlineHearingId)).thenReturn(cohOnlineHearing);
+        SscsCaseDetails caseDetails = createCaseDetails(someCaseId, "someCaseReference", "firstName", "lastName");
+        when(ccdService.getByCaseId(cohOnlineHearing.getCcdCaseId(), idamTokens)).thenReturn(caseDetails);
+
+        Optional<SscsCaseDetails> sscsCaseDetails = underTest.getCcdCaseByIdentifier(onlineHearingId);
+
+        assertThat(sscsCaseDetails.isPresent(), is(true));
+        assertThat(sscsCaseDetails.get(), is(caseDetails));
+    }
+
+    @Test
+    public void getsACcdCaseByIdentifierFromCcdId() {
+        SscsCaseDetails caseDetails = createCaseDetails(someCaseId, "someCaseReference", "firstName", "lastName");
+        when(ccdService.getByCaseId(someCaseId, idamTokens)).thenReturn(caseDetails);
+
+        Optional<SscsCaseDetails> sscsCaseDetails = underTest.getCcdCaseByIdentifier(someCaseId.toString());
+
+        assertThat(sscsCaseDetails.isPresent(), is(true));
+        assertThat(sscsCaseDetails.get(), is(caseDetails));
+    }
+
     @Test(expected = IllegalStateException.class)
     public void exceptionWhenGettingAHearingIfThereIsMoreThanOneCaseWithAnOnlinePanel() {
         SscsCaseDetails caseDetails1 = createCaseDetails(someCaseId, "someCaseReference", "firstName", "lastName");

--- a/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadServiceTest.java
@@ -90,7 +90,7 @@ public class EvidenceUploadServiceTest {
     public void uploadsEvidenceAndAddsItToDraftSscsDocumentsInCcd() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetails(someQuestionId, fileName, documentUrl, evidenceCreatedOn);
         final int originalNumberOfSscsDocuments = sscsCaseDetails.getData().getDraftSscsDocument().size();
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
         Optional<Evidence> evidenceOptional = evidenceUploadService.uploadDraftHearingEvidence(someOnlineHearingId, file);
 
@@ -110,7 +110,7 @@ public class EvidenceUploadServiceTest {
     @Test
     public void submitsEvidenceAddsDraftSscsDocumentsToSscsDocumentsInCcdWhenThereAreNoSscsDocuments() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetails(someQuestionId, fileName, documentUrl, evidenceCreatedOn);
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
         UploadedEvidence evidenceDescriptionPdf = mock(UploadedEvidence.class);
         when(storeEvidenceDescriptionService.storePdf(
                 someCcdCaseId,
@@ -154,7 +154,7 @@ public class EvidenceUploadServiceTest {
         sscsCaseDetails.getData().setSscsDocument(list);
 
         final int originalNumberOfSscsDocuments = sscsCaseDetails.getData().getSscsDocument().size();
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
         UploadedEvidence evidenceDescriptionPdf = mock(UploadedEvidence.class);
         when(storeEvidenceDescriptionService.storePdf(
                 someCcdCaseId,
@@ -307,7 +307,7 @@ public class EvidenceUploadServiceTest {
     @Test
     public void uploadsEvidenceWhenThereAreNotAlreadySscsDocumentsInCcd() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetailsWithoutCcdDocuments();
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
         Optional<Evidence> evidenceOptional = evidenceUploadService.uploadDraftHearingEvidence(someOnlineHearingId, file);
 
@@ -338,7 +338,7 @@ public class EvidenceUploadServiceTest {
     public void uploadsEvidenceToQuestionAndAddsItToDraftCorDocumentsInCcd() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetails(someQuestionId, fileName, documentUrl, evidenceCreatedOn);
         final int originalNumberOfCorDocuments = sscsCaseDetails.getData().getDraftCorDocument().size();
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
         Optional<Evidence> evidenceOptional = evidenceUploadService.uploadDraftQuestionEvidence(someOnlineHearingId, someQuestionId, file);
 
@@ -358,7 +358,7 @@ public class EvidenceUploadServiceTest {
     @Test
     public void uploadsEvidenceToQuestionWhenThereAreNotAlreadyCorDocumentsInCcd() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetailsWithoutCcdDocuments();
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
         Optional<Evidence> evidenceOptional = evidenceUploadService.uploadDraftQuestionEvidence(someOnlineHearingId, someQuestionId, file);
 
@@ -388,8 +388,7 @@ public class EvidenceUploadServiceTest {
     @Test
     public void listEvidenceWhenQuestionUnanswered() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetails(someQuestionId, fileName, documentUrl, evidenceCreatedOn);
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
-
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
         List<Evidence> evidenceList = evidenceUploadService.listQuestionEvidence(someOnlineHearingId, someQuestionId);
 
@@ -403,7 +402,7 @@ public class EvidenceUploadServiceTest {
         sscsCaseDetails.getData().setCorDocument(sscsCaseDetails.getData().getDraftCorDocument());
         sscsCaseDetails.getData().setDraftCorDocument(null);
 
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
 
         List<Evidence> evidenceList = evidenceUploadService.listQuestionEvidence(someOnlineHearingId, someQuestionId);
@@ -445,7 +444,7 @@ public class EvidenceUploadServiceTest {
     @Test
     public void deleteEvidenceFromCcd() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetails(someQuestionId, fileName, documentUrl, evidenceCreatedOn);
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
         boolean hearingFound = evidenceUploadService.deleteDraftHearingEvidence(someOnlineHearingId, someEvidenceId);
 
@@ -463,7 +462,7 @@ public class EvidenceUploadServiceTest {
     @Test
     public void deleteEvidenceIfCaseHadNoEvidence() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetailsWithoutCcdDocuments();
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
         boolean hearingFound = evidenceUploadService.deleteDraftHearingEvidence(someOnlineHearingId, someEvidenceId);
 
@@ -484,7 +483,7 @@ public class EvidenceUploadServiceTest {
     @Test
     public void deleteEvidenceForQuestionFromCcd() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetails(someQuestionId, fileName, documentUrl, evidenceCreatedOn);
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
         boolean hearingFound = evidenceUploadService.deleteQuestionEvidence(someOnlineHearingId, someEvidenceId);
 
@@ -502,7 +501,7 @@ public class EvidenceUploadServiceTest {
     @Test
     public void deleteEvidenceForQuestionIfCaseHadNoCohEvidence() {
         SscsCaseDetails sscsCaseDetails = createSscsCaseDetailsWithoutCcdDocuments();
-        when(onlineHearingService.getCcdCase(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
+        when(onlineHearingService.getCcdCaseByIdentifier(someOnlineHearingId)).thenReturn(Optional.of(sscsCaseDetails));
 
         boolean hearingFound = evidenceUploadService.deleteQuestionEvidence(someOnlineHearingId, someEvidenceId);
 


### PR DESCRIPTION
You used to have to have an online hearing id to add evidence or an
appellant statement to a case. Made it so you can use either online
hearing id or ccd case id to do this.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-6334

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
