### PR TITLE
SSCS-6779 Use ScannedDocument object for further evidence

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
@@ -4,6 +4,7 @@ import static java.util.Collections.*;
 import static java.util.stream.Collectors.*;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.collections4.ListUtils.union;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.ATTACH_SCANNED_DOCS;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -110,28 +111,57 @@ public class EvidenceUploadService {
     public boolean submitHearingEvidence(String identifier, EvidenceDescription description) {
         return onlineHearingService.getCcdCaseByIdentifier(identifier)
                 .map(caseDetails -> {
-                    Long ccdCaseId = caseDetails.getId();
-                    log.info("Submitting draft document for case [" + ccdCaseId + "]");
-
                     SscsCaseData sscsCaseData = caseDetails.getData();
+                    Long ccdCaseId = caseDetails.getId();
 
-                    EvidenceDescriptionPdfData data = new EvidenceDescriptionPdfData(caseDetails, description, getFileNames(sscsCaseData));
-                    CohEventActionContext storePdfContext = storeEvidenceDescriptionService.storePdf(ccdCaseId, identifier, data);
+                    if (sscsCaseData.getAppeal() == null || sscsCaseData.getAppeal().getHearingType() == null || sscsCaseData.getAppeal().getHearingType().equals("cor")) {
+                        log.info("Submitting draft document for case [" + ccdCaseId + "]");
 
-                    List<SscsDocument> draftSscsDocument = storePdfContext.getDocument().getData().getDraftSscsDocument();
-                    List<SscsDocument> newSscsDocumentsList = union(
-                            emptyIfNull(storePdfContext.getDocument().getData().getSscsDocument()),
-                            emptyIfNull(draftSscsDocument)
-                    );
+                        EvidenceDescriptionPdfData data = new EvidenceDescriptionPdfData(caseDetails, description, getFileNames(sscsCaseData));
+                        CohEventActionContext storePdfContext = storeEvidenceDescriptionService.storePdf(ccdCaseId, identifier, data);
 
-                    sscsCaseData.setSscsDocument(newSscsDocumentsList);
-                    sscsCaseData.setDraftSscsDocument(Collections.emptyList());
+                        List<SscsDocument> draftSscsDocument = storePdfContext.getDocument().getData().getDraftSscsDocument();
+                        List<SscsDocument> newSscsDocumentsList = union(
+                                emptyIfNull(storePdfContext.getDocument().getData().getSscsDocument()),
+                                emptyIfNull(draftSscsDocument)
+                        );
 
-                    ccdService.updateCase(sscsCaseData, ccdCaseId, UPLOAD_COR_DOCUMENT, "SSCS - cor evidence uploaded", UPDATED_SSCS, idamService.getIdamTokens());
+                        sscsCaseData.setSscsDocument(newSscsDocumentsList);
+                        sscsCaseData.setDraftSscsDocument(Collections.emptyList());
 
-                    evidenceUploadEmailService.sendToDwp(storePdfContext.getPdf(), draftSscsDocument, caseDetails);
+                        ccdService.updateCase(sscsCaseData, ccdCaseId, UPLOAD_COR_DOCUMENT, "SSCS - cor evidence uploaded", UPDATED_SSCS, idamService.getIdamTokens());
 
-                    return true;
+                        evidenceUploadEmailService.sendToDwp(storePdfContext.getPdf(), draftSscsDocument, caseDetails);
+
+                        return true;
+                    } else {
+                        List<ScannedDocument> scannedDocs = new ArrayList<>();
+                        for (SscsDocument draftSscsDocument : caseDetails.getData().getDraftSscsDocument()) {
+                            ScannedDocument scannedDocument = ScannedDocument.builder().value(
+                                    ScannedDocumentDetails.builder()
+                                        .type("other")
+                                        .url(draftSscsDocument.getValue().getDocumentLink())
+                                        .fileName(draftSscsDocument.getValue().getDocumentFileName())
+                                        .scannedDate(draftSscsDocument.getValue().getDocumentDateAdded())
+                                        .build()).build();
+
+                            scannedDocs.add(scannedDocument);
+                        }
+
+                        List<ScannedDocument> newScannedDocumentsList = union(
+                                emptyIfNull(caseDetails.getData().getScannedDocuments()),
+                                emptyIfNull(scannedDocs)
+                        );
+
+                        sscsCaseData.setScannedDocuments(newScannedDocumentsList);
+                        sscsCaseData.setDraftSscsDocument(Collections.emptyList());
+
+                        sscsCaseData.setEvidenceHandled("No");
+
+                        ccdService.updateCase(sscsCaseData, ccdCaseId, ATTACH_SCANNED_DOCS.getCcdType(), "SSCS - upload evidence from MYA", "Uploaded a further evidence document", idamService.getIdamTokens());
+
+                        return true;
+                    }
                 })
                 .orElse(false);
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
@@ -138,10 +138,9 @@ public class EvidenceUploadService {
                         return true;
                     } else {
                         List<ScannedDocument> scannedDocs = new ArrayList<>();
-                        DateTimeFormatter DateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-                        
+                        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
                         for (SscsDocument draftSscsDocument : caseDetails.getData().getDraftSscsDocument()) {
-                            LocalDate ld = LocalDate.parse(draftSscsDocument.getValue().getDocumentDateAdded(), DateFormatter);
+                            LocalDate ld = LocalDate.parse(draftSscsDocument.getValue().getDocumentDateAdded(), dateFormatter);
                             LocalDateTime ldt = LocalDateTime.of(ld, LocalDateTime.now().toLocalTime());
 
                             ScannedDocument scannedDocument = ScannedDocument.builder().value(

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
@@ -6,6 +6,7 @@ import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.collections4.ListUtils.union;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.ATTACH_SCANNED_DOCS;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -137,13 +138,18 @@ public class EvidenceUploadService {
                         return true;
                     } else {
                         List<ScannedDocument> scannedDocs = new ArrayList<>();
+                        DateTimeFormatter DateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                        
                         for (SscsDocument draftSscsDocument : caseDetails.getData().getDraftSscsDocument()) {
+                            LocalDate ld = LocalDate.parse(draftSscsDocument.getValue().getDocumentDateAdded(), DateFormatter);
+                            LocalDateTime ldt = LocalDateTime.of(ld, LocalDateTime.now().toLocalTime());
+
                             ScannedDocument scannedDocument = ScannedDocument.builder().value(
                                     ScannedDocumentDetails.builder()
                                         .type("other")
                                         .url(draftSscsDocument.getValue().getDocumentLink())
                                         .fileName(draftSscsDocument.getValue().getDocumentFileName())
-                                        .scannedDate(LocalDateTime.parse(draftSscsDocument.getValue().getDocumentDateAdded()).toString())
+                                            .scannedDate(ldt.toString())
                                         .build()).build();
 
                             scannedDocs.add(scannedDocument);

--- a/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscscorbackend/service/evidence/EvidenceUploadService.java
@@ -6,6 +6,7 @@ import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.collections4.ListUtils.union;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.ATTACH_SCANNED_DOCS;
 
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -142,7 +143,7 @@ public class EvidenceUploadService {
                                         .type("other")
                                         .url(draftSscsDocument.getValue().getDocumentLink())
                                         .fileName(draftSscsDocument.getValue().getDocumentFileName())
-                                        .scannedDate(draftSscsDocument.getValue().getDocumentDateAdded())
+                                        .scannedDate(LocalDateTime.parse(draftSscsDocument.getValue().getDocumentDateAdded()).toString())
                                         .build()).build();
 
                             scannedDocs.add(scannedDocument);


### PR DESCRIPTION
- When non cor case, use the scannedDocument object to process evidence uploaded from MYA

https://tools.hmcts.net/jira/browse/SSCS-6779